### PR TITLE
Feature/control_poly_parametrization

### DIFF
--- a/awebox/ocp/collocation.py
+++ b/awebox/ocp/collocation.py
@@ -129,7 +129,7 @@ class Collocation(object):
 
         return None
 
-    def build_interpolator(self, nlp_params, V, var_type):
+    def build_interpolator(self, nlp_params, V):
         """Build interpolating function over the interval
         using lagrange polynomials
 
@@ -138,7 +138,7 @@ class Collocation(object):
         @return interpolation function
         """
 
-        def coll_interpolator(time_grid, name, dim):
+        def coll_interpolator(time_grid, name, dim, var_type):
             """Interpolating function
 
             @param time_grid list with time points

--- a/awebox/ocp/collocation.py
+++ b/awebox/ocp/collocation.py
@@ -205,21 +205,20 @@ class Collocation(object):
 
         return xp_jk
 
-    def get_collocation_variables_struct(self, variables_dict):
+    def get_collocation_variables_struct(self, variables_dict, u_param):
+
+        entry_list = [
+            cas.entry('xd', struct = variables_dict['xd']),
+            cas.entry('xa', struct = variables_dict['xa'])
+        ]
 
         if 'xl' in list(variables_dict.keys()):
-            coll_var = cas.struct_symSX([
-                cas.entry('xd', struct = variables_dict['xd']),
-                cas.entry('xa', struct = variables_dict['xa']),
-                cas.entry('xl', struct = variables_dict['xl'])
-            ])
-        else:
-            coll_var = cas.struct_symSX([
-                cas.entry('xd', struct = variables_dict['xd']),
-                cas.entry('xa', struct = variables_dict['xa']),
-            ])
+            entry_list += [cas.entry('xl', struct = variables_dict['xl'])]
 
-        return coll_var
+        if u_param == 'poly':
+            entry_list += [cas.entry('u', struct = variables_dict['u'])]
+
+        return cas.struct_symMX(entry_list)
 
     def __integrate_integral_outputs(self, Integral_outputs_list, integral_outputs_deriv, model, tf):
 

--- a/awebox/ocp/discretization.py
+++ b/awebox/ocp/discretization.py
@@ -82,7 +82,7 @@ def setup_nlp_v(nlp_numerics_options, model, formulation, Collocation):
 
         # add collocation node variables
         d = nlp_numerics_options['collocation']['d'] # interpolating polynomial order
-        coll_var = Collocation.get_collocation_variables_struct(variables_dict)
+        coll_var = Collocation.get_collocation_variables_struct(variables_dict, nlp_numerics_options['collocation']['u_param'])
         entry_tuple += (cas.entry('coll_var', struct = coll_var, repeat= [nk,d]),)
 
     elif nlp_numerics_options['discretization'] == 'multiple_shooting':

--- a/awebox/ocp/discretization.py
+++ b/awebox/ocp/discretization.py
@@ -59,11 +59,15 @@ def setup_nlp_v(nlp_numerics_options, model, formulation, Collocation):
     # define interval struct entries for controls and states
     entry_tuple = (
         cas.entry('xd', repeat = [nk+1], struct = variables_dict['xd']),
-        cas.entry('u',  repeat = [nk],   struct = variables_dict['u']),
         )
 
     # add additional variables according to provided options
     if nlp_numerics_options['discretization'] == 'direct_collocation':
+
+        if nlp_numerics_options['collocation']['u_param'] == 'zoh':
+            entry_tuple += (
+                cas.entry('u',  repeat = [nk],   struct = variables_dict['u']),
+            )
 
         # add algebraic variables at interval except for radau case
         if nlp_numerics_options['collocation']['scheme'] != 'radau':
@@ -82,6 +86,10 @@ def setup_nlp_v(nlp_numerics_options, model, formulation, Collocation):
         entry_tuple += (cas.entry('coll_var', struct = coll_var, repeat= [nk,d]),)
 
     elif nlp_numerics_options['discretization'] == 'multiple_shooting':
+
+        entry_tuple += (
+            cas.entry('u',  repeat = [nk],   struct = variables_dict['u']),
+        )
 
         # add slack variables for inequalities
         if nlp_numerics_options['slack_constraints'] == True and model.constraints_dict['inequality']:

--- a/awebox/opti/initialization_modular.py
+++ b/awebox/opti/initialization_modular.py
@@ -1073,7 +1073,8 @@ def __generate_vals(V_init, primitive, nlp, model, time_grid_parameters, interpo
             V_init['xd', k, name] = continuous_guess[name]
         if k < (n_max):
             if model.options['tether']['control_var'] == 'ddl_t':
-                V_init['u', k + n_current, 'ddl_t'] = continuous_guess['ddl_t']
+                if 'u' in V_init.keys():
+                    V_init['u', k + n_current, 'ddl_t'] = continuous_guess['ddl_t']
         if nlp.discretization == 'direct_collocation':
             if k == n_max:
                 d_vals = d_max
@@ -1084,7 +1085,9 @@ def __generate_vals(V_init, primitive, nlp, model, time_grid_parameters, interpo
                 continuous_guess, interpolation_variables = __get_continuous_guess(t_coll, time_grid_parameters, interpolation_parameters, primitive, model, interpolation_scheme)
                 for name in struct_op.subkeys(model.variables, 'xd'):
                     V_init['coll_var', k, j, 'xd', name] = continuous_guess[name]
-
+                if model.options['tether']['control_var'] == 'ddl_t':
+                    if 'u' in V_init.keys():
+                        V_init['coll_var', k, j, 'u', 'ddl_t'] = continuous_guess['ddl_t']
     return V_init
 
 def __get_continuous_guess(t_cont, time_grid_parameters, interpolation_parameters, primitive, model, interpolation_scheme):

--- a/awebox/opti/preparation.py
+++ b/awebox/opti/preparation.py
@@ -95,7 +95,11 @@ def set_p_fix_num(V_ref, nlp, model, options):
                 p_fix_num['p', 'weights', variable_type, name] = 1.0
             # set references
             if variable_type == 'u':
-                p_fix_num['p', 'ref', variable_type, :, name] = V_ref[variable_type, :, name]
+                if 'u' in V_ref.keys():
+                    p_fix_num['p', 'ref', variable_type, :, name] = V_ref[variable_type, :, name]
+                else:
+                    p_fix_num['p', 'ref', 'coll_var', :, :, variable_type, name] = V_ref['coll_var', :, :, variable_type, name]
+
             elif variable_type == 'theta':
                 p_fix_num['p', 'ref', variable_type, name] = V_ref[variable_type, name]
             elif variable_type in {'xd','xl','xa'}:

--- a/awebox/opti/preparation.py
+++ b/awebox/opti/preparation.py
@@ -160,17 +160,29 @@ def set_initial_bounds(nlp, model, formulation, options, V_init):
     # set fictitious forces bounds
     for name in list(model.variables_dict['u'].keys()):
         if 'fict' in name:
-            V_bounds['lb']['u', :, name] = -cas.inf
-            V_bounds['ub']['u', :, name] = cas.inf
+            if 'u' in V_init.keys():
+                V_bounds['lb']['u', :, name] = -cas.inf
+                V_bounds['ub']['u', :, name] = cas.inf
+            else:
+                V_bounds['lb']['coll_var', :, :, 'u', name] = -cas.inf
+                V_bounds['ub']['coll_var', :, :, 'u', name] = cas.inf
 
     # set state bounds
     if (options['initialization']['type'] == 'lift_mode') or (options['initialization']['type'] == 'tracking'):
         if 'ddl_t' in list(model.variables_dict['u'].keys()):
-            V_bounds['lb']['u', :, 'ddl_t'] = 0.
-            V_bounds['ub']['u', :, 'ddl_t'] = 0.
+            if 'u' in V_init.keys():
+                V_bounds['lb']['u', :, 'ddl_t'] = 0.
+                V_bounds['ub']['u', :, 'ddl_t'] = 0.
+            else:
+                V_bounds['lb']['coll_var', :, :, 'u', 'ddl_t'] = 0.
+                V_bounds['ub']['coll_var', :, :, 'u', 'ddl_t'] = 0.
         elif 'dddl_t' in list(model.variables_dict['u'].keys()):
-            V_bounds['lb']['u', :, 'dddl_t'] = 0.
-            V_bounds['ub']['u', :, 'dddl_t'] = 0.
+            if 'u' in V_init.keys():
+                V_bounds['lb']['u', :, 'dddl_t'] = 0.
+                V_bounds['ub']['u', :, 'dddl_t'] = 0.
+            else:
+                V_bounds['lb']['coll_var', :, :, 'u', 'dddl_t'] = 0.
+                V_bounds['ub']['coll_var', :, :, 'u', 'dddl_t'] = 0.
 
     # if phase-fix, first free dl_t before introducing phase-fix in switch to power
     if nlp.V['theta','t_f'].shape[0] > 1:

--- a/awebox/opti/scheduling.py
+++ b/awebox/opti/scheduling.py
@@ -27,6 +27,7 @@ update model that generates the
 cost update and bounds update to be used in the homotopy process
 python-3.5 / casadi-3.4.5
 - authors: rachel leuthold, alu-fr 2018
+- edited: jochem de schutter, alu-fr 2018-2019
 '''
 
 import awebox.tools.struct_operations as struct_op
@@ -335,7 +336,10 @@ def update_final_bounds(bound_name, V_bounds, nlp, update):
         V_bounds[bound_type][var_type, bound_name] = nlp.V_bounds[bound_type][var_type, bound_name]
 
     if var_type == 'u':
-        V_bounds[bound_type][var_type, :, bound_name] = nlp.V_bounds[bound_type][var_type, :, bound_name]
+        if 'u' in list(V_bounds[bound_type].keys()):
+            V_bounds[bound_type][var_type, :, bound_name] = nlp.V_bounds[bound_type][var_type, :, bound_name]
+        else:
+            V_bounds[bound_type]['coll_var', :, :, var_type, bound_name] = nlp.V_bounds[bound_type]['coll_var', :, :, var_type, bound_name]
 
     if var_type in {'xl', 'xa', 'xd'}:
 
@@ -362,7 +366,10 @@ def update_nonfinal_bounds(bound_name, V_bounds, model, nlp, update):
             V_bounds[bound_type][var_type, bound_name] = scaled_value
 
         if var_type == 'u':
-            V_bounds[bound_type][var_type, :, bound_name] = scaled_value
+            if 'u' in list(V_bounds[bound_type].keys()):
+                V_bounds[bound_type][var_type, :, bound_name] = scaled_value
+            else:
+                V_bounds[bound_type]['coll_var', :, :, var_type, bound_name] = scaled_value
 
         if var_type in {'xl', 'xa', 'xd'}:
             if var_type in list(nlp.V.keys()): # not the case for xa and xl in radau collocation

--- a/awebox/opts/default.py
+++ b/awebox/opts/default.py
@@ -311,6 +311,7 @@ def set_default_options(default_user_options, help_options):
         ('nlp',  None,               None,  'discretization',      'direct_collocation',   ('possible options', ['direct_collocation']),'x'),
         ('nlp',  'collocation',      None, 'd',                    4,                      ('degree of lagrange polynomials inside collocation interval [int]', None),'t'),
         ('nlp',  'collocation',      None, 'scheme',               'radau',                ('collocation scheme', ['radau','legendre']),'x'),
+        ('nlp',  'collocation',      None, 'u_param',              'poly',                 ('control parameterization in collocation interval', ['poly','zoh']),'x'),
         ('nlp',  None,               None, 'lift_xddot',           True,                   ('lift xddot values on interval nodes', [True, False]),'x'),
         ('nlp',  None,               None, 'lift_xa',              True,                   ('lift xa values on interval nodes', [True, False]),'x'),
         ('nlp',  None,               None, 'phase_fix_reelout',    0.7,                    ('time fraction of reel-out phase', None),'x'),

--- a/awebox/tools/struct_operations.py
+++ b/awebox/tools/struct_operations.py
@@ -717,9 +717,18 @@ def setup_warmstart_data(nlp, warmstart_trial):
             g_coll = warmstart_trial['g_opt']
 
             # initialize regular variables
-            for var_type in set(['xd','u','theta','phi','xi']):
+            for var_type in set(['xd','theta','phi','xi']):
                 V_init_proposed[var_type] = V_coll[var_type]
                 lam_x_proposed[var_type]  = lam_x_coll[var_type]
+
+            if 'u' in list(V_coll.keys()):
+                V_init_proposed['u'] = V_coll['u']
+                lam_x_proposed['u']  = lam_x_coll['u']
+            else:
+                for i in range(n_k):
+                    # note: this does not give the actual mean, implement with quadrature weights instead
+                    V_init_proposed['u',i] = np.mean(cas.horzcat(*V_coll['coll_var',i,:,'u']))
+                    lam_x_proposed['u',i]  = np.mean(cas.horzcat(*lam_x_coll['coll_var',i,:,'u']))
 
             if 'xddot' in list(V_init_proposed.keys()):
                 V_init_proposed['xddot'] = Xdot_coll['xd']

--- a/awebox/tools/struct_operations.py
+++ b/awebox/tools/struct_operations.py
@@ -400,7 +400,11 @@ def si_to_scaled(model, V_ori):
 
             elif variable_type == 'u':
                 for kdx in range(n_k):
-                    V[variable_type, kdx, name] = V[variable_type, kdx, name] / model.scaling[variable_type][name]
+                    if variable_type in list(V.keys()):
+                        V[variable_type, kdx, name] = V[variable_type, kdx, name] / model.scaling[variable_type][name]
+                    else:
+                        for ddx in range(d):
+                            V['coll_var', kdx, ddx, variable_type, name] = V['coll_var', kdx, ddx, variable_type, name] / model.scaling[variable_type][name]
 
             elif variable_type in set(['xa', 'xl','xd','xddot']):
                 if variable_type in list(V.keys()):
@@ -436,7 +440,11 @@ def scaled_to_si(variables, scaling, n_k, d, V_ori):
 
             elif variable_type == 'u':
                 for kdx in range(n_k):
-                    V[variable_type, kdx, name] = V[variable_type, kdx, name] * scaling[variable_type][name]
+                    if variable_type in list(V.keys()):
+                        V[variable_type, kdx, name] = V[variable_type, kdx, name] * scaling[variable_type][name]
+                    else:
+                        for ddx in range(d):
+                            V['coll_var', kdx, ddx, variable_type, name] = V['coll_var', kdx, ddx, variable_type, name] *scaling[variable_type][name]
 
             elif variable_type in set(['xa', 'xl','xd','xddot']):
                 if variable_type in list(V.keys()):

--- a/awebox/tools/struct_operations.py
+++ b/awebox/tools/struct_operations.py
@@ -114,6 +114,8 @@ def get_variables_at_time(nlp_options, V, Xdot, model, kdx, ddx=None):
                         var_list.append(V['coll_var', kdx, 0, var_type])
                     else:
                         var_list.append(V['coll_var', kdx, ddx, var_type])
+                else:
+                    var_list.append(V[var_type, kdx])
             else:
                 var_list.append(V[var_type, kdx])
 
@@ -239,6 +241,10 @@ def get_var_ref_at_time(nlp_options, P, V, Xdot, model, kdx, ddx=None):
                         var_list.append(np.zeros(variables[var_type].shape))
                     else:
                         var_list.append(P['p', 'ref','coll_var', kdx, ddx, var_type])
+                else:
+                    var_list.append(P['p', 'ref',var_type, kdx])
+            else:
+                var_list.append(P['p', 'ref',var_type, kdx])
 
         # parameters
         elif var_type == 'theta':

--- a/awebox/tools/struct_operations.py
+++ b/awebox/tools/struct_operations.py
@@ -60,6 +60,7 @@ def get_variables_at_time(nlp_options, V, Xdot, model, kdx, ddx=None):
     if nlp_options['discretization'] == 'direct_collocation':
         direct_collocation = True
         scheme = nlp_options['collocation']['scheme']
+        u_param = nlp_options['collocation']['u_param']
     else:
         direct_collocation = False
 
@@ -106,7 +107,15 @@ def get_variables_at_time(nlp_options, V, Xdot, model, kdx, ddx=None):
 
         # controls
         elif var_type == 'u':
-            var_list.append(V[var_type, kdx])
+
+            if direct_collocation:
+                if (u_param == 'poly'):
+                    if ddx == None:
+                        var_list.append(V['coll_var', kdx, 0, var_type])
+                    else:
+                        var_list.append(V['coll_var', kdx, ddx, var_type])
+            else:
+                var_list.append(V[var_type, kdx])
 
         # parameters
         elif var_type == 'theta':
@@ -182,6 +191,7 @@ def get_var_ref_at_time(nlp_options, P, V, Xdot, model, kdx, ddx=None):
     if nlp_options['discretization'] == 'direct_collocation':
         direct_collocation = True
         scheme = nlp_options['collocation']['scheme']
+        u_param = nlp_options['collocation']['u_param']
     else:
         direct_collocation = False
 
@@ -222,7 +232,13 @@ def get_var_ref_at_time(nlp_options, P, V, Xdot, model, kdx, ddx=None):
 
         # controls
         elif var_type == 'u':
-            var_list.append(P['p', 'ref', var_type, kdx])
+
+            if direct_collocation:
+                if (u_param == 'poly'):
+                    if ddx == None:
+                        var_list.append(np.zeros(variables[var_type].shape))
+                    else:
+                        var_list.append(P['p', 'ref','coll_var', kdx, ddx, var_type])
 
         # parameters
         elif var_type == 'theta':

--- a/awebox/viz/tools.py
+++ b/awebox/viz/tools.py
@@ -887,7 +887,12 @@ def interpolate_data(plot_dict, cosmetics):
         for name in list(struct_op.subkeys(variables_dict,var_type)):
             plot_dict[var_type][name] = []
             for j in range(variables_dict[var_type,name].shape[0]):
-                values_ip = interpolator(plot_dict['time_grids']['ip'], name, j, var_type)
+                if plot_dict['discretization'] == 'direct_collocation':
+                    values_ip = interpolator(plot_dict['time_grids']['ip'], name, j, var_type)
+                else:
+                    values, time_grid = merge_xa_values(V_plot, var_type, name, j, plot_dict, cosmetics)
+                    # interpolate
+                    values_ip = spline_interpolation(time_grid, values, plot_dict['time_grids']['ip'], n_points, name)
                 plot_dict[var_type][name] += [values_ip]
 
     # u-values

--- a/awebox/viz/tools.py
+++ b/awebox/viz/tools.py
@@ -614,15 +614,16 @@ def plot_control_block(cosmetics, V_opt, plt, fig, plot_table_r, plot_table_c, i
 
     # read in inputs
     tgrid_u = plot_dict['time_grids']['u']
+    tgrid_ip = plot_dict['time_grids']['ip']
 
-    try:
-        plt.subplot(plot_table_r, plot_table_c, idx)
-        for jdx in range(number_dim):
+    plt.subplot(plot_table_r, plot_table_c, idx)
+    for jdx in range(number_dim):
+        if plot_dict['u_param'] == 'poly':
+            plt.plot(tgrid_ip, plot_dict['u'][name][jdx])
+        else:
             plt.step(tgrid_u, np.array(V_opt[location, :, name, jdx]))
-        plt.grid(True)
-        plt.title(name)
-    except BaseException:
-        32.0
+    plt.grid(True)
+    plt.title(name)
 
 # def get_velocity(zz,params,wind):
 

--- a/awebox/viz/tools.py
+++ b/awebox/viz/tools.py
@@ -852,10 +852,8 @@ def interpolate_data(plot_dict, cosmetics):
     nlp_options = plot_dict['options']['nlp']
     V_plot = plot_dict['V_plot']
     if plot_dict['Collocation'] is not None:
-        interpolator = plot_dict['Collocation'].build_interpolator(nlp_options, V_plot,'xd')
+        interpolator = plot_dict['Collocation'].build_interpolator(nlp_options, V_plot)
         u_param = plot_dict['u_param']
-        if u_param == 'poly':
-            u_interpolator = plot_dict['Collocation'].build_interpolator(nlp_options, V_plot,'u')
     else:
         u_param = 'zoh'
 
@@ -881,7 +879,7 @@ def interpolate_data(plot_dict, cosmetics):
             if cosmetics['interpolation']['type'] == 'spline' or plot_dict['discretization'] == 'multiple_shooting':
                 values_ip = spline_interpolation(time_grid, values, plot_dict['time_grids']['ip'], n_points, name)
             elif cosmetics['interpolation']['type'] == 'poly' and plot_dict['discretization'] == 'direct_collocation':
-                values_ip = interpolator(plot_dict['time_grids']['ip'], name, j)
+                values_ip = interpolator(plot_dict['time_grids']['ip'], name, j, 'xd')
             plot_dict['xd'][name] += [values_ip]
 
     # xa-values
@@ -889,10 +887,7 @@ def interpolate_data(plot_dict, cosmetics):
         for name in list(struct_op.subkeys(variables_dict,var_type)):
             plot_dict[var_type][name] = []
             for j in range(variables_dict[var_type,name].shape[0]):
-                # merge values
-                values, time_grid = merge_xa_values(V_plot, var_type, name, j, plot_dict, cosmetics)
-                # interpolate
-                values_ip = spline_interpolation(time_grid, values, plot_dict['time_grids']['ip'], n_points, name)
+                values_ip = interpolator(plot_dict['time_grids']['ip'], name, j, var_type)
                 plot_dict[var_type][name] += [values_ip]
 
     # u-values
@@ -905,7 +900,7 @@ def interpolate_data(plot_dict, cosmetics):
                 time_grids = plot_dict['time_grids']
                 values_ip = sample_and_hold_controls(time_grids, control)
             elif u_param == 'poly':
-                values_ip = u_interpolator(plot_dict['time_grids']['ip'], name, j)
+                values_ip = interpolator(plot_dict['time_grids']['ip'], name, j, 'u')
             plot_dict['u'][name] += [values_ip]
 
     # output values

--- a/awebox/viz/tools.py
+++ b/awebox/viz/tools.py
@@ -621,7 +621,7 @@ def plot_control_block(cosmetics, V_opt, plt, fig, plot_table_r, plot_table_c, i
         if plot_dict['u_param'] == 'poly':
             plt.plot(tgrid_ip, plot_dict['u'][name][jdx])
         else:
-            plt.step(tgrid_u, np.array(V_opt[location, :, name, jdx]))
+            plt.step(tgrid_u, np.array(V_opt[location, :, name, jdx]),where='post')
     plt.grid(True)
     plt.title(name)
 

--- a/test/reg/test_discretization.py
+++ b/test/reg/test_discretization.py
@@ -32,6 +32,7 @@ def test_integrators():
     # specify direct collocation options
     base_options['nlp']['n_k'] = 40
     base_options['nlp']['discretization'] = 'direct_collocation'
+    base_options['nlp']['collocation']['u_param'] = 'zoh'
     base_options['nlp']['collocation']['scheme'] = 'radau'
     base_options['nlp']['collocation']['d'] = 4
 


### PR DESCRIPTION
Without making any a priori assumptions on hardware constraints or controller sampling times, there's no reason to use ZOH as the standard control parameterization for trajectory generation. 

Therefore, this feature implements polynomial-based (of order `d`) control parameterization and makes it the default setting. This will increase optimality and will lead to continuous-time control trajectories and possibly smoother state (derivative) trajectories.

- Change the setting with `options['nlp']['collocation']['u_param'] = 'poly' / 'zoh'`
- Controls are automatically plotted as ZOH or as piecewise polynomials respectively.
- Algebraic variables are now also plotted as `d`-order polynomials (instead of hacky spline interpolation).