### PR TITLE
MPC interface

### DIFF
--- a/awebox/ocp/operation.py
+++ b/awebox/ocp/operation.py
@@ -74,7 +74,7 @@ def determine_if_terminal_inequalities(options):
 def determine_if_periodic(options):
 
     enforce_periodicity = bool(True)
-    if options['trajectory']['type'] in ['transition', 'compromised_landing', 'nominal_landing', 'aero_test', 'launch']:
+    if options['trajectory']['type'] in ['transition', 'compromised_landing', 'nominal_landing', 'aero_test', 'launch','mpc']:
          enforce_periodicity = bool(False)
 
     return enforce_periodicity
@@ -92,7 +92,7 @@ def determine_if_initial_conditions(options):
 
     enforce_initial_conditions = bool(False)
 
-    if options['trajectory']['type'] in ['launch']:
+    if options['trajectory']['type'] in ['launch','mpc']:
          enforce_initial_conditions = bool(True)
 
     return enforce_initial_conditions

--- a/awebox/opts/funcs.py
+++ b/awebox/opts/funcs.py
@@ -92,7 +92,7 @@ def build_options_dict(options, help_options, architecture):
         options_tree.append((dict_type, 'geometry', None, name,geometry[name], ('???', None),'x'))
 
     ### switch off phase fixing for landing/transition trajectories
-    if user_options['trajectory']['type'] in ['nominal_landing', 'compromised_landing', 'transition']:
+    if user_options['trajectory']['type'] in ['nominal_landing', 'compromised_landing', 'transition', 'mpc']:
         phase_fix = False
     else:
         phase_fix = user_options['trajectory']['lift_mode']['phase_fix']

--- a/awebox/trial.py
+++ b/awebox/trial.py
@@ -92,6 +92,9 @@ class Trial(object):
         if is_standalone_trial:
             print_op.log_license_info()
 
+        if self.__options['user_options']['trajectory']['type'] == 'mpc':
+            raise ValueError('Build method not supported for MPC trials. Use PMPC wrapper instead.')
+
         logging.info('')
 
         logging.info('Building trial (%s) ...', self.__name)
@@ -119,6 +122,9 @@ class Trial(object):
 
         # get save_flag
         self.__save_flag = save_flag
+
+        if self.__options['user_options']['trajectory']['type'] == 'mpc':
+            raise ValueError('Optimize method not supported for MPC trials. Use PMPC wrapper instead.')
 
         logging.info('Optimizing trial (%s) ...', self.__name)
         logging.info('')


### PR DESCRIPTION
With the current codebase, we can create in a very versatile and reliable way (OCP-)NLPs for `awebox` models using either direct collocation or multiple shooting.

This well-tested functionality can easily be put to use for MPC prototyping (for `awebox` models). Therefore this PR allows one to create an `awebox.Nlp` object for MPC application. The resulting NLP information can then be processed by the user in their own MPC implementation.

I wouldn't yet add support to use the `Optimization` class (or the `Trial` interface to it) since the homotopy and initialization procedures are redundant in this case. It might involve less overhead to write a basic `Pmpc` class. This class would include a wrapper around the `awebox.NLP`-class, automatic reference generation based on optimized trial (for tracking), elimination of homotopy optimization variables and symbolic system parameters for performance. ...

- use the feature with `options['user_options']['trajectory']['type'] = 'mpc'`
- choose a discretization method and numerical options of your liking.
- You can now build the options, model and NLP manually and use the results in your own code. 
- NLP contains dynamic and path constraints + additionally an initial constraint. Might want to include the option of a terminal constraint later.

Tests run through.
