### PR TITLE
Feature/plot reference

### DIFF
--- a/awebox/opti/optimization.py
+++ b/awebox/opti/optimization.py
@@ -159,9 +159,10 @@ class Optimization(object):
         sweep_toggle = False
         cost_fun = nlp.cost_components[0]
         cost = struct_op.evaluate_cost_dict(cost_fun, V_plot, self.__p_fix_num)
+        V_ref = nlp.V(self.__p_fix_num['p','ref'])
         visualization.plot(V_plot, visualization.options, [self.__outputs_init,
                                                            self.__outputs_opt],
-                           self.__integral_outputs_opt, self.__debug_flags, self.__time_grids, cost, self.__name, sweep_toggle, fig_name=fig_name)
+                           self.__integral_outputs_opt, self.__debug_flags, self.__time_grids, cost, self.__name, sweep_toggle, V_ref, fig_name=fig_name)
 
         return None
 
@@ -176,6 +177,8 @@ class Optimization(object):
         self.__V_init = nlp.V(self.__arg['x0'])
 
         self.__p_fix_num = nlp.P(self.__arg['p'])
+
+        self.__V_ref = nlp.V(self.__p_fix_num['p','ref'])
 
         if 'initial_guess' in self.__debug_locations or self.__debug_locations == 'all':
             self.__make_debug_plot(self.__V_init, nlp, visualization, 'initial_guess')
@@ -482,9 +485,10 @@ class Optimization(object):
         integral_outputs_opt = nlp_integral_outputs(nlp_integral_outputs_fun(V_final, self.__p_fix_num))
 
         # time grids
-        time_grids = {}
+        time_grids = {'ref':{}}
         for grid in nlp.time_grids:
             time_grids[grid] = nlp.time_grids[grid](V_final['theta','t_f'])
+            time_grids['ref'][grid] = nlp.time_grids[grid](self.__V_ref['theta','t_f'])
 
         # set properties
         self.__outputs_opt = outputs_opt
@@ -555,6 +559,14 @@ class Optimization(object):
     @V_opt.setter
     def V_opt(self, value):
         logging.warning('Cannot set V_opt object.')
+
+    @property
+    def V_ref(self):
+        return self.__V_ref
+
+    @V_ref.setter
+    def V_ref(self, value):
+        logging.warning('Cannot set V_ref object.')
 
     @property
     def V_final(self):

--- a/awebox/opti/optimization.py
+++ b/awebox/opti/optimization.py
@@ -159,7 +159,7 @@ class Optimization(object):
         sweep_toggle = False
         cost_fun = nlp.cost_components[0]
         cost = struct_op.evaluate_cost_dict(cost_fun, V_plot, self.__p_fix_num)
-        V_ref = nlp.V(self.__p_fix_num['p','ref'])
+        V_ref = self.__V_ref
         visualization.plot(V_plot, visualization.options, [self.__outputs_init,
                                                            self.__outputs_opt],
                            self.__integral_outputs_opt, self.__debug_flags, self.__time_grids, cost, self.__name, sweep_toggle, V_ref, fig_name=fig_name)

--- a/awebox/opti/optimization.py
+++ b/awebox/opti/optimization.py
@@ -57,6 +57,7 @@ class Optimization(object):
         self.__return_status_numeric = {}
         self.__outputs_init = None
         self.__outputs_opt = None
+        self.__outputs_ref = None
         self.__time_grids = None
         self.__debug_fig_num = 1000
 
@@ -161,7 +162,7 @@ class Optimization(object):
         cost = struct_op.evaluate_cost_dict(cost_fun, V_plot, self.__p_fix_num)
         V_ref = self.__V_ref
         visualization.plot(V_plot, visualization.options, [self.__outputs_init,
-                                                           self.__outputs_opt],
+                                                           self.__outputs_opt, self.__outputs_ref],
                            self.__integral_outputs_opt, self.__debug_flags, self.__time_grids, cost, self.__name, sweep_toggle, V_ref, fig_name=fig_name)
 
         return None
@@ -478,6 +479,7 @@ class Optimization(object):
         [nlp_outputs, nlp_output_fun] = nlp.output_components
         outputs_init = nlp_outputs(nlp_output_fun(V_initial, self.__p_fix_num))
         outputs_opt = nlp_outputs(nlp_output_fun(V_final, self.__p_fix_num))
+        outputs_ref = nlp_outputs(nlp_output_fun(self.__V_ref, self.__p_fix_num))
 
         # integral outputs
         [nlp_integral_outputs, nlp_integral_outputs_fun] = nlp.integral_output_components
@@ -493,6 +495,7 @@ class Optimization(object):
         # set properties
         self.__outputs_opt = outputs_opt
         self.__outputs_init = outputs_init
+        self.__outputs_ref = outputs_ref
         self.__integral_outputs_init = integral_outputs_init
         self.__integral_outputs_opt = integral_outputs_opt
         self.__integral_outputs_fun = nlp_integral_outputs_fun
@@ -626,7 +629,7 @@ class Optimization(object):
 
     @property
     def output_vals(self):
-        return [self.__outputs_init, self.__outputs_opt]
+        return [self.__outputs_init, self.__outputs_opt, self.__outputs_ref]
 
     @property
     def integral_output_vals(self):

--- a/awebox/opts/default.py
+++ b/awebox/opts/default.py
@@ -442,6 +442,7 @@ def set_default_options(default_user_options, help_options):
         ('visualization', 'cosmetics', 'trajectory', 'margin',      0.05,           ('trajectory figure margins', None), 'x'),
         ('visualization', 'cosmetics', None,         'save_figs',   False,          ('save the figures', [True, False]), 'x'),
         ('visualization', 'cosmetics', None,         'plot_coll',   True,           ('plot the collocation variables', [True, False]), 'x'),
+        ('visualization', 'cosmetics', None,         'plot_ref',    False,          ('plot the tracking reference trajectory', [True, False]), 'x'),
         ('visualization', 'cosmetics', 'interpolation', 'include',  True,           ('???', None), 'x'),
         ('visualization', 'cosmetics', 'interpolation', 'type',     'poly',         ('???', None), 'x'),
         ('visualization', 'cosmetics', 'interpolation', 'N',        100,            ('???', None), 'x'),

--- a/awebox/sweep.py
+++ b/awebox/sweep.py
@@ -137,7 +137,8 @@ class Sweep:
                 timings = single_trial.optimization.timings
                 cost_fun = single_trial.nlp.cost_components[0]
                 cost = struct_op.evaluate_cost_dict(cost_fun, V_plot, p_fix_num)
-                recalibrated_plot_dict = tools.recalibrate_visualization(V_plot, single_trial.visualization.plot_dict, output_vals, integral_outputs_final, parametric_options, time_grids, cost, name, iterations=iterations, return_status_numeric=return_status_numeric, timings=timings)
+                V_ref = single_trial.optimization.V_ref
+                recalibrated_plot_dict = tools.recalibrate_visualization(V_plot, single_trial.visualization.plot_dict, output_vals, integral_outputs_final, parametric_options, time_grids, cost, name, V_ref, iterations=iterations, return_status_numeric=return_status_numeric, timings=timings)
                 self.__plot_dict[trial_to_run][param] = copy.deepcopy(recalibrated_plot_dict)
 
                 # overwrite outputs to work around pickle bug

--- a/awebox/trial.py
+++ b/awebox/trial.py
@@ -264,7 +264,8 @@ class Trial(object):
         solution_dict['options'] = self.__options
         solution_dict['output_vals'] = [
             copy.deepcopy(self.__optimization.output_vals[0]),
-            copy.deepcopy(self.__optimization.output_vals[1])
+            copy.deepcopy(self.__optimization.output_vals[1]),
+            copy.deepcopy(self.__optimization.output_vals[2])
         ]
         solution_dict['integral_outputs_final'] = self.__optimization.integral_outputs_final
         solution_dict['stats'] = self.__optimization.stats

--- a/awebox/trial.py
+++ b/awebox/trial.py
@@ -257,6 +257,7 @@ class Trial(object):
         # parametric sweep data
         solution_dict['V_opt'] = self.__optimization.V_opt
         solution_dict['V_final'] = self.__optimization.V_final
+        solution_dict['V_ref'] = self.__optimization.V_ref
         solution_dict['options'] = self.__options
         solution_dict['output_vals'] = [
             copy.deepcopy(self.__optimization.output_vals[0]),

--- a/awebox/trial.py
+++ b/awebox/trial.py
@@ -150,7 +150,9 @@ class Trial(object):
 
         cost_fun = self.nlp.cost_components[0]
         cost = struct_op.evaluate_cost_dict(cost_fun, self.optimization.V_opt, self.optimization.p_fix_num)
-        self.visualization.recalibrate(self.optimization.V_opt, self.visualization.plot_dict, self.optimization.output_vals, self.optimization.integral_outputs_final, self.options, self.optimization.time_grids, cost, self.name)
+        self.visualization.recalibrate(self.optimization.V_opt,self.visualization.plot_dict, self.optimization.output_vals,
+                                        self.optimization.integral_outputs_final, self.options, self.optimization.time_grids,
+                                        cost, self.name, self.__optimization.V_ref)
 
         # perform quality check
         self.__quality.check_quality(self)
@@ -173,9 +175,10 @@ class Trial(object):
             cost = self.__solution_dict['cost']
         time_grids = self.__solution_dict['time_grids']
         integral_outputs_final = self.__solution_dict['integral_outputs_final']
+        V_ref = self.__solution_dict['V_ref']
         trial_name = self.__solution_dict['name']
 
-        self.__visualization.plot(V_plot, parametric_options, output_vals, integral_outputs_final, flags, time_grids, cost, trial_name, sweep_toggle,'plot',fig_num)
+        self.__visualization.plot(V_plot, parametric_options, output_vals, integral_outputs_final, flags, time_grids, cost, trial_name, sweep_toggle, V_ref, 'plot',fig_num)
 
         return None
 

--- a/awebox/trial_funcs.py
+++ b/awebox/trial_funcs.py
@@ -119,7 +119,8 @@ def interpolate_data(trial, freq):
     cost = struct_op.evaluate_cost_dict(cost_fun, V_plot, p_fix_num)
     name = trial.name
     parametric_options = trial.options
-    plot_dict = tools.recalibrate_visualization(V_plot, plot_dict, output_vals, integral_outputs_final, parametric_options, time_grids, cost, name, N=N)
+    V_ref = trial.optimization.V_ref
+    plot_dict = tools.recalibrate_visualization(V_plot, plot_dict, output_vals, integral_outputs_final, parametric_options, time_grids, cost, name, V_ref, N=N)
 
     return plot_dict
 

--- a/awebox/viz/output.py
+++ b/awebox/viz/output.py
@@ -698,7 +698,12 @@ def plot_constraints(plot_dict, cosmetics, fig_num, constr_type):
                     label = name+'_'+str(idx)
 
                 # plot data with label
-                axes[counter].plot(tgrid, output_vals, label = label)
+                p = axes[counter].plot(tgrid, output_vals, label = label)
+
+                if cosmetics['plot_ref']:
+                    ref_output_vals = plot_dict['ref']['outputs'][constr_name][name][idx]
+                    ref_tgrid = plot_dict['time_grids']['ref']['ip']
+                    axes[counter].plot(ref_tgrid, ref_output_vals, linestyle = '--',color = p[-1].get_color())
 
         axes[counter].plot(tgrid, np.zeros(tgrid.shape),'k--')
         axes[counter].set_ylabel(constr_name)

--- a/awebox/viz/output.py
+++ b/awebox/viz/output.py
@@ -33,25 +33,32 @@ import casadi.tools as cas
 def plot_outputs(plot_dict, cosmetics, fig_name, output_path, fig_num = None):
 
     time_grid_ip = plot_dict['time_grids']['ip']
+    ref_time_grid_ip = plot_dict['time_grids']['ref']['ip']
+
     outputs = plot_dict['outputs']
+    ref_outputs = plot_dict['ref']['outputs']
     output_key_list = output_path.split(':')
     if len(output_key_list) == 1:
         output = outputs[output_key_list[0]]
+        ref_output = ref_outputs[output_key_list[0]]
     elif len(output_key_list) == 2:
         output = outputs[output_key_list[0]][output_key_list[1]]
+        ref_output = ref_outputs[output_key_list[0]][output_key_list[1]]
     elif len(output_key_list) == 3:
         output = outputs[output_key_list[0]][output_key_list[1]][output_key_list[2]]
+        ref_output = ref_outputs[output_key_list[0]][output_key_list[1]][output_key_list[2]]
     else:
         raise ValueError('Error: Wrong recursion depth (' + str(len(output_key_list)) + ') for output plots!' + str(output_key_list))
     recursive_output_plot(output, fig_name, time_grid_ip, fig_num)
+    recursive_output_plot(ref_output, fig_name, ref_time_grid_ip,  plt.gcf().number , linestyle = '--')
 
     return None
 
-def recursive_output_plot(outputs, fig_name, time_grid_ip, fig_num = None):
+def recursive_output_plot(outputs, fig_name, time_grid_ip, fig_num = None, linestyle = '-'):
 
     try:
         for key in list(outputs.keys()):
-            recursive_output_plot(outputs[key], key, time_grid_ip, fig_num)
+            recursive_output_plot(outputs[key], key, time_grid_ip, fig_num, linestyle = linestyle)
     except:
         if fig_num is None:
             fig = plt.figure()
@@ -59,7 +66,7 @@ def recursive_output_plot(outputs, fig_name, time_grid_ip, fig_num = None):
         else:
             fig = plt.figure(fig_num)
 
-        plt.plot(time_grid_ip, outputs[0])
+        plt.plot(time_grid_ip, outputs[0], linestyle = linestyle)
         plt.title(fig_name)
 
 def plot_induction_factor_vs_tether_reel(solution_dict, cosmetics, reload_dict, fig_num):

--- a/awebox/viz/tools.py
+++ b/awebox/viz/tools.py
@@ -87,14 +87,14 @@ def get_naca_shell(chord, naca="0012", center_at_quarter_chord = True):
 
     return x
 
-def make_side_plot(ax, vertically_stacked_array, side, plot_color, plot_marker=' ', label=None, alpha = 1):
+def make_side_plot(ax, vertically_stacked_array, side, plot_color, plot_marker=' ', label=None, alpha = 1, linestyle = '-'):
     vsa = np.array(vertically_stacked_array)
 
     if vsa.shape[0] == 3 and vsa.shape[1] > 3:
         vsa = vsa.T
 
     if side == 'isometric':
-        ax.plot(vsa[:, 0], vsa[:, 1], zs=vsa[:, 2], color=plot_color, marker=plot_marker, label=label, alpha = alpha)
+        ax.plot(vsa[:, 0], vsa[:, 1], zs=vsa[:, 2], color=plot_color, marker=plot_marker, label=label, alpha = alpha, linestyle = linestyle)
     else:
         if side == 'xy':
             idx = 0
@@ -108,7 +108,7 @@ def make_side_plot(ax, vertically_stacked_array, side, plot_color, plot_marker='
             idx = 0
             jdx = 2
 
-        ax.plot(vsa[:, idx], vsa[:, jdx], color=plot_color, marker=plot_marker, label = label, alpha = alpha)
+        ax.plot(vsa[:, idx], vsa[:, jdx], color=plot_color, marker=plot_marker, label = label, alpha = alpha, linestyle = linestyle)
 
     return None
 
@@ -465,6 +465,7 @@ def plot_trajectory_contents(ax, plot_dict, cosmetics, side, init_colors=bool(Fa
 
     # get kite locations
     kite_locations = []
+    kite_ref_locations = []
     kite_rotations = []
     skipping_kite_locations = []
     skipping_kite_rotations = []
@@ -472,6 +473,7 @@ def plot_trajectory_contents(ax, plot_dict, cosmetics, side, init_colors=bool(Fa
     for n in kite_nodes:
 
         traj = []
+        traj_ref = []
         rot = []
 
         parent = parent_map[n]
@@ -481,6 +483,7 @@ def plot_trajectory_contents(ax, plot_dict, cosmetics, side, init_colors=bool(Fa
                 cas.vertcat(plot_dict['xd']['q' + str(n) + str(parent)][j])#,
                 # plot_dict['xd']['q' + str(n) + str(parent)][j][0])
             )
+            traj_ref.append(cas.vertcat(plot_dict['ref']['xd']['q' + str(n) + str(parent)][j]))
             # traj.append(merge_xd_values(V_plot,'q' + str(n) + str(parent),j, plot_dict, cosmetics)[0])
 
         if int(kite_dof) == 6:
@@ -493,6 +496,7 @@ def plot_trajectory_contents(ax, plot_dict, cosmetics, side, init_colors=bool(Fa
                 # rot.append(merge_output_values(outputs,'aerodynamics', 'r'+ str(n),j, plot_dict, cosmetics)[0])
 
         kite_locations.append(traj)
+        kite_ref_locations.append(traj_ref)
         kite_rotations.append(rot)
 
     skip_value = nlp_options['collocation']['d'] + 1
@@ -520,9 +524,15 @@ def plot_trajectory_contents(ax, plot_dict, cosmetics, side, init_colors=bool(Fa
         vertically_stacked_kite_locations = cas.horzcat(kite_locations[i][0],
                                                     kite_locations[i][1],
                                                     kite_locations[i][2])
+
+        vertically_stacked_kite_ref_locations = cas.horzcat(kite_ref_locations[i][0],
+                                                    kite_ref_locations[i][1],
+                                                    kite_ref_locations[i][2])
         if old_label == label:
             label = None
         make_side_plot(ax, vertically_stacked_kite_locations, side, local_color, label=label)
+        make_side_plot(ax, vertically_stacked_kite_ref_locations, side, local_color, label=label,linestyle='--')
+
         old_label = label
 
         if (cosmetics['trajectory']['kite_bodies'] and plot_kites):

--- a/awebox/viz/tools.py
+++ b/awebox/viz/tools.py
@@ -719,7 +719,7 @@ def calibrate_visualization(model, nlp, name, options):
 
     return plot_dict
 
-def recalibrate_visualization(V_plot, plot_dict, output_vals, integral_outputs_final, options, time_grids, cost, name, iterations=None, return_status_numeric=None, timings=None, N=None):
+def recalibrate_visualization(V_plot, plot_dict, output_vals, integral_outputs_final, options, time_grids, cost, name, V_ref, iterations=None, return_status_numeric=None, timings=None, N=None, ):
     """
     Recalibrate plot dict with all calibration operation that need to be perfomed once for every plot.
     :param plot_dict: plot dictionary before recalibration
@@ -744,7 +744,7 @@ def recalibrate_visualization(V_plot, plot_dict, output_vals, integral_outputs_f
 
     # add V_plot to dict
     plot_dict['V_plot'] = struct_op.scaled_to_si(variables, scaling, n_k, d, V_plot)
-
+    plot_dict['V_ref'] = struct_op.scaled_to_si(variables, scaling, n_k, d, V_ref)
     # get new name
     plot_dict['name'] = name
 

--- a/awebox/viz/tools.py
+++ b/awebox/viz/tools.py
@@ -953,6 +953,8 @@ def interpolate_ref_data(plot_dict, cosmetics):
     # extract information
     variables_dict = plot_dict['variables']
     nlp_options = plot_dict['options']['nlp']
+    outputs_dict = plot_dict['outputs_dict']
+    output_vals = plot_dict['output_vals'][2]
     V_ref = plot_dict['V_ref']
     if plot_dict['Collocation'] is not None:
         interpolator = plot_dict['Collocation'].build_interpolator(nlp_options, V_ref)
@@ -961,7 +963,7 @@ def interpolate_ref_data(plot_dict, cosmetics):
         u_param = 'zoh'
 
     # add states and outputs to plotting dict
-    plot_dict['ref'] = {'xd': {},'u':{},'xa':{},'xl':{},'time_grids':{}}
+    plot_dict['ref'] = {'xd': {},'u':{},'xa':{},'xl':{},'time_grids':{},'outputs':{}}
 
     # interpolating time grid
     n_points = cosmetics['interpolation']['N']
@@ -1006,6 +1008,18 @@ def interpolate_ref_data(plot_dict, cosmetics):
             elif u_param == 'poly':
                 values_ip = interpolator(plot_dict['time_grids']['ref']['ip'], name, j, 'u')
             plot_dict['ref']['u'][name] += [values_ip]
+
+    # output values
+    for output_type in list(outputs_dict.keys()):
+        plot_dict['ref']['outputs'][output_type] = {}
+        for name in list(outputs_dict[output_type].keys()):
+            plot_dict['ref']['outputs'][output_type][name] = []
+            for j in range(outputs_dict[output_type][name].shape[0]):
+                # merge values
+                values, time_grid, ndim = merge_output_values(output_vals, output_type, name, j, plot_dict, cosmetics)
+                # inteprolate
+                values_ip = spline_interpolation(time_grid, values, plot_dict['time_grids']['ref']['ip'], n_points, name)
+                plot_dict['ref']['outputs'][output_type][name] += [values_ip]
 
     return plot_dict
 

--- a/awebox/viz/tools.py
+++ b/awebox/viz/tools.py
@@ -619,9 +619,16 @@ def plot_control_block(cosmetics, V_opt, plt, fig, plot_table_r, plot_table_c, i
     plt.subplot(plot_table_r, plot_table_c, idx)
     for jdx in range(number_dim):
         if plot_dict['u_param'] == 'poly':
-            plt.plot(tgrid_ip, plot_dict['u'][name][jdx])
+            p = plt.plot(tgrid_ip, plot_dict['u'][name][jdx])
+            if plot_dict['options']['visualization']['cosmetics']['plot_ref']:
+                plt.plot(plot_dict['time_grids']['ref']['ip'], plot_dict['ref']['u'][name][jdx],
+                    linestyle= '--', color = p[-1].get_color() )
+
         else:
-            plt.step(tgrid_u, np.array(V_opt[location, :, name, jdx]),where='post')
+            p = plt.step(tgrid_u, np.array(V_opt[location, :, name, jdx]),where='post')
+            if plot_dict['options']['visualization']['cosmetics']['plot_ref']:
+                plt.step(plot_dict['time_grids']['ref']['ip'], plot_dict['ref']['u'][name][jdx],where='post',
+                    linestyle =  '--', color = p[-1].get_color())
     plt.grid(True)
     plt.title(name)
 

--- a/awebox/viz/variables.py
+++ b/awebox/viz/variables.py
@@ -81,7 +81,11 @@ def plot_states(plot_dict, cosmetics, fig_name, individual_state=None, fig_num=N
             counter += 1
             ax = plt.axes(axes[counter-1])
             for jdx in range(variables_dict['xd'][name].shape[0]):
-                plt.plot(tgrid_ip, plot_dict['xd'][name][jdx])
+                p = plt.plot(tgrid_ip, plot_dict['xd'][name][jdx])
+                if cosmetics['plot_ref']:
+                    plt.plot(plot_dict['time_grids']['ref']['ip'], plot_dict['ref']['xd'][name][jdx],
+                        linestyle= '--', color = p[-1].get_color() )
+
                 plt.title(name)
 
     for name in integral_variables_to_plot:
@@ -156,7 +160,10 @@ def plot_lifted(plot_dict, cosmetics, fig_name, individual_state=None, fig_num=N
             counter += 1
             ax = plt.axes(axes[counter-1])
             for jdx in range(variables_dict['xl'][name].shape[0]):
-                plt.plot(tgrid_ip, plot_dict['xl'][name][jdx])
+                p = plt.plot(tgrid_ip, plot_dict['xl'][name][jdx])
+                if cosmetics['plot_ref']:
+                    plt.plot(plot_dict['time_grids']['ref']['ip'], plot_dict['ref']['xl'][name][jdx],
+                        linestyle= '--', color = p[-1].get_color() )
                 plt.title(name)
 
     for name in integral_variables_to_plot:
@@ -243,7 +250,10 @@ def plot_algebraic_variables(plot_dict, cosmetics, fig_name):
         parent = parent_map[n]
         lambdavec = plot_dict['xa']['lambda' + str(n) + str(parent)]
         tgrid_ip = plot_dict['time_grids']['ip']
-        plt.plot(tgrid_ip, lambdavec[0])
+        p = plt.plot(tgrid_ip, lambdavec[0])
+        if cosmetics['plot_ref']:
+            plt.plot(plot_dict['time_grids']['ref']['ip'], plot_dict['ref']['xa'][name][jdx],
+                linestyle= '--', color = p[-1].get_color() )
         legend_names.append('lambda' + str(n) + str(parent))
     plt.legend(legend_names)
     plt.suptitle(fig_name)

--- a/awebox/viz/variables.py
+++ b/awebox/viz/variables.py
@@ -252,8 +252,8 @@ def plot_algebraic_variables(plot_dict, cosmetics, fig_name):
         tgrid_ip = plot_dict['time_grids']['ip']
         p = plt.plot(tgrid_ip, lambdavec[0])
         if cosmetics['plot_ref']:
-            plt.plot(plot_dict['time_grids']['ref']['ip'], plot_dict['ref']['xa'][name][jdx],
-                linestyle= '--', color = p[-1].get_color() )
+            plt.plot(plot_dict['time_grids']['ref']['ip'], plot_dict['ref']['xa']['lambda' + str(n) + str(parent)][0],
+                linestyle= '--', color = p[-1].get_color())
         legend_names.append('lambda' + str(n) + str(parent))
     plt.legend(legend_names)
     plt.suptitle(fig_name)

--- a/awebox/viz/variables.py
+++ b/awebox/viz/variables.py
@@ -228,10 +228,17 @@ def plot_invariants(plot_dict, cosmetics, fig_name):
         parent = parent_map[n]
         invariants = plot_dict['outputs']['tether_length']
         tgrid_ip = plot_dict['time_grids']['ip']
+
+        if cosmetics['plot_ref']:
+            ref_invariants = plot_dict['ref']['outputs']['tether_length']
+            ref_tgrid_ip = plot_dict['time_grids']['ref']['ip']
+
         for prefix in ['','d', 'dd']:
-            plt.semilogy(tgrid_ip, abs(invariants[prefix + 'c' + str(n) + str(parent)][0]))
-            legend_names.append(prefix + 'c' + str(n) + str(parent))
-    plt.legend(legend_names)
+            p = plt.semilogy(tgrid_ip, abs(invariants[prefix + 'c' + str(n) + str(parent)][0]), label = prefix + 'c' + str(n) + str(parent))
+            if cosmetics['plot_ref']:
+                plt.semilogy(ref_tgrid_ip, abs(ref_invariants[prefix + 'c' + str(n) + str(parent)][0]), linestyle = '--', color = p[-1].get_color())
+
+    plt.legend()
     plt.suptitle(fig_name)
 
     return None

--- a/awebox/viz/visualization.py
+++ b/awebox/viz/visualization.py
@@ -61,13 +61,13 @@ class Visualization(object):
 
         return None
 
-    def recalibrate(self, V_plot, plot_dict, output_vals, integral_outputs_final, parametric_options, time_grids, cost, name):
+    def recalibrate(self, V_plot, plot_dict, output_vals, integral_outputs_final, parametric_options, time_grids, cost, name, V_ref):
 
-        self.__plot_dict = tools.recalibrate_visualization(V_plot, plot_dict, output_vals, integral_outputs_final, parametric_options, time_grids, cost, name)
+        self.__plot_dict = tools.recalibrate_visualization(V_plot, plot_dict, output_vals, integral_outputs_final, parametric_options, time_grids, cost, name, V_ref)
 
         return None
 
-    def plot(self, V_plot, parametric_options, output_vals, integral_outputs_final, flags, time_grids, cost, name, sweep_toggle, fig_name='plot', fig_num = None):
+    def plot(self, V_plot, parametric_options, output_vals, integral_outputs_final, flags, time_grids, cost, name, sweep_toggle, V_ref, fig_name='plot', fig_num = None):
         """
         Generate plots with given parametric and visualization options
         :param V_plot: plot data (scaled)
@@ -77,7 +77,7 @@ class Visualization(object):
         """
 
         # recalibrate plot_dict
-        self.recalibrate(V_plot, self.__plot_dict, output_vals, integral_outputs_final, parametric_options, time_grids, cost, name)
+        self.recalibrate(V_plot, self.__plot_dict, output_vals, integral_outputs_final, parametric_options, time_grids, cost, name, V_ref)
 
         if type(flags) is not list:
             flags = [flags]

--- a/test/int/test_visualization.py
+++ b/test/int/test_visualization.py
@@ -26,6 +26,7 @@ def test_visualization():
     options['user_options']['tether_drag_model'] = 'trivial'
     options['nlp']['n_k'] = 2
     options['solver']['max_iter'] = 0
+    options['visualization']['cosmetics']['plot_ref'] = True
 
     # build trial and optimize
     trial = awe.Trial(options, 'trial1')


### PR DESCRIPTION
This feature adds the option to plot the (tracking) reference along with the states, controls and algebraic variables. In the default case, it's turned off as the power-optimal trajectory generally deviates a lot from the reference (which is the initial guess). But it's useful for tracking trajectory optimization and MPC applications.

```python
options['visualization']['cosmetics']['plot_ref'] = True
```

It works for the following cases:

```python
trial.plot(['states','controls','algebraic_variables','lifted_variables'])
trial.plot(['quad','constraints','invariants','outputs:performance:freelout'])
```
