### PR TITLE
Correct expression for lift-induced drag for elliptical wings

### DIFF
--- a/awebox/mdl/aero/kite_dir/three_dof_kite.py
+++ b/awebox/mdl/aero/kite_dir/three_dof_kite.py
@@ -93,7 +93,7 @@ def get_outputs(options, atmos, wind, variables, outputs, parameters, architectu
 
         # lift and drag coefficients
         CL = coeff[0]
-        CD = parameters['theta0','aero','CD0'] + 0.02 * CL ** 2
+        CD = parameters['theta0','aero','CD0'] + CL ** 2/ (np.pi*parameters['theta0','geometry','ar'])
 
         # lift and drag force
         f_lift = CL * 1. / 2. * rho_infty * cas.mtimes(ua.T, ua) * parameters['theta0','geometry','s_ref'] * ehat_l


### PR DESCRIPTION
Remove hard-coded value CD,L = 0.02*CL^2.

Replace with lift-induced drag expression for elliptical wings: CD,L = CL^2 / (pi*AR).