### PR TITLE
Bugfix/6 dof write to csv

### DIFF
--- a/awebox/opti/diagnostics.py
+++ b/awebox/opti/diagnostics.py
@@ -59,7 +59,7 @@ def print_runtime_values(stats):
 
     awelogger.logger.info("{0:.<30}: {1:<30}".format('solver return status', stats['return_status']))
     awelogger.logger.info("{0:.<30}: {1:<30}".format('number of iterations', stats['iter_count']))
-    # awelogger.logger.info("{0:.<30}: {1:<30}".format('main loop wall time', stats['t_wall_solver']))
+    awelogger.logger.info("{0:.<30}: {1:<30}".format('main loop wall time', stats['t_wall_solver']))
     awelogger.logger.info('')
 
     return None

--- a/awebox/opti/diagnostics.py
+++ b/awebox/opti/diagnostics.py
@@ -59,7 +59,7 @@ def print_runtime_values(stats):
 
     awelogger.logger.info("{0:.<30}: {1:<30}".format('solver return status', stats['return_status']))
     awelogger.logger.info("{0:.<30}: {1:<30}".format('number of iterations', stats['iter_count']))
-    awelogger.logger.info("{0:.<30}: {1:<30}".format('main loop wall time', stats['t_wall_solver']))
+    # awelogger.logger.info("{0:.<30}: {1:<30}".format('main loop wall time', stats['t_wall_solver']))
     awelogger.logger.info('')
 
     return None

--- a/awebox/tools/vector_operations.py
+++ b/awebox/tools/vector_operations.py
@@ -334,7 +334,7 @@ def estimate_1d_frequency(x, sample_step=1, dt=1.0):
 def isRotationMatrix(R):
     Rt = np.transpose(R)
     shouldBeIdentity = np.dot(Rt, R)
-    I = np.identity(3, dtype=R.dtype)
+    I = np.identity(3)
     n = np.linalg.norm(I - shouldBeIdentity)
     return n < 1e-1
 

--- a/awebox/trial_funcs.py
+++ b/awebox/trial_funcs.py
@@ -153,16 +153,18 @@ def write_data_row(pcdw, plot_dict, write_csv_dict, tgrid_ip, k, rotation_repres
                 # convert rotations from dcm to euler
                 if variable[0] == 'r' and rotation_representation == 'euler':
                     dcm = []
-                    for i in range(3):
+                    for i in range(9):
                         dcm = cas.vertcat(dcm, plot_dict[variable_type][variable][i][k])
-                    var = vect_op.rotationMatrixToEulerAngles(dcm)
+                    var = vect_op.rotationMatrixToEulerAngles(cas.reshape(dcm,3,3))
+                    for index in range(3):
+                        write_csv_dict[variable_type + '_' + variable + '_' + str(index)] = str(var[index])
                 elif rotation_representation not in ['euler', 'dcm']:
-                    awelogger.logger.error('Error: Only euler agnles and direct cosine matrix supported.')
+                    awelogger.logger.error('Error: Only euler angles and direct cosine matrix supported.')
                 else:
                     var = plot_dict[variable_type][variable]
-                variable_length = len(var)
-                for index in range(variable_length):
-                    write_csv_dict[variable_type + '_' + variable + '_' + str(index)] = str(var[index][k])
+                    variable_length = len(var)
+                    for index in range(variable_length):
+                        write_csv_dict[variable_type + '_' + variable + '_' + str(index)] = str(var[index][k])
 
     write_csv_dict['time'] = tgrid_ip[k]
 


### PR DESCRIPTION
Fixes bug when saving optimized trial to .csv-file.
- `dtype` was called for `DM` object in the case of 6DOF models, which doesn't have this attribute.
- Also fixes creating Euler angles from optimal rotation matrix information from 6DOF trial.

Tests run through.