### PR TITLE
Feature/plot var bounds

### DIFF
--- a/awebox/opts/default.py
+++ b/awebox/opts/default.py
@@ -424,6 +424,7 @@ def set_default_options(default_user_options, help_options):
         ('visualization', 'cosmetics', None,         'save_figs',   False,          ('save the figures', [True, False]), 'x'),
         ('visualization', 'cosmetics', None,         'plot_coll',   True,           ('plot the collocation variables', [True, False]), 'x'),
         ('visualization', 'cosmetics', None,         'plot_ref',    False,          ('plot the tracking reference trajectory', [True, False]), 'x'),
+        ('visualization', 'cosmetics', None,         'plot_bounds', False,          ('plot the variable bounds', [True, False]), 'x'),
         ('visualization', 'cosmetics', 'interpolation', 'include',  True,           ('???', None), 'x'),
         ('visualization', 'cosmetics', 'interpolation', 'type',     'poly',         ('???', None), 'x'),
         ('visualization', 'cosmetics', 'interpolation', 'N',        100,            ('???', None), 'x'),

--- a/awebox/viz/tools.py
+++ b/awebox/viz/tools.py
@@ -1128,3 +1128,20 @@ def assemble_variable_slice_from_interpolated_data(plot_dict, index, var_type):
 
         var_slice = local_dict(collected_vals)
         return var_slice
+
+def plot_bounds(plot_dict, var_type, name, jdx, tgrid_ip, p):
+
+    bounds = plot_dict['variable_bounds'][var_type][name]
+    scaling = plot_dict['scaling'][var_type][name]
+    lb = bounds['lb']
+    if type(lb) != float:
+        lb = lb[jdx]
+    ub = bounds['ub']
+    if type(ub) != float:
+        ub = ub[jdx]
+    if lb > -np.inf:
+        plt.plot(tgrid_ip, [lb*scaling]*len(tgrid_ip), linestyle='dotted', color = p[-1].get_color())
+    if ub < np.inf:
+        plt.plot(tgrid_ip, [ub*scaling]*len(tgrid_ip), linestyle='dotted', color = p[-1].get_color())
+
+    return None

--- a/awebox/viz/tools.py
+++ b/awebox/viz/tools.py
@@ -641,12 +641,16 @@ def plot_control_block(cosmetics, V_opt, plt, fig, plot_table_r, plot_table_c, i
     for jdx in range(number_dim):
         if plot_dict['u_param'] == 'poly':
             p = plt.plot(tgrid_ip, plot_dict['u'][name][jdx])
+            if plot_dict['options']['visualization']['cosmetics']['plot_bounds']:
+                plot_bounds(plot_dict, 'u', name, jdx, tgrid_ip, p)
             if plot_dict['options']['visualization']['cosmetics']['plot_ref']:
                 plt.plot(plot_dict['time_grids']['ref']['ip'], plot_dict['ref']['u'][name][jdx],
                     linestyle= '--', color = p[-1].get_color() )
 
         else:
             p = plt.step(tgrid_ip, plot_dict['u'][name][jdx],where='post')
+            if plot_dict['options']['visualization']['cosmetics']['plot_bounds']:
+                plot_bounds(plot_dict, 'u', name, jdx, tgrid_ip, p)
             if plot_dict['options']['visualization']['cosmetics']['plot_ref']:
                 plt.step(plot_dict['time_grids']['ref']['ip'], plot_dict['ref']['u'][name][jdx],where='post',
                     linestyle =  '--', color = p[-1].get_color())

--- a/awebox/viz/tools.py
+++ b/awebox/viz/tools.py
@@ -713,6 +713,7 @@ def calibrate_visualization(model, nlp, name, options):
     plot_dict['variables'] = struct_op.strip_of_contents(model.variables)
     plot_dict['variables_dict'] = struct_op.strip_of_contents(model.variables_dict)
     plot_dict['scaling'] = model.scaling
+    plot_dict['variable_bounds'] = model.variable_bounds
 
     # wind information
     u_ref = model.options['params']['wind']['u_ref']

--- a/awebox/viz/variables.py
+++ b/awebox/viz/variables.py
@@ -52,8 +52,8 @@ def plot_states(plot_dict, cosmetics, fig_name, individual_state=None, fig_num=N
     counter += len(integral_variables)
 
     if individual_state == None:
-        plot_table_r = 4
-        plot_table_c = int(np.ceil(np.float(counter) / np.float(plot_table_r)))
+        plot_table_c = 3
+        plot_table_r = int(np.ceil(np.float(counter) / np.float(plot_table_c)))
     else:
         plot_table_r = len(variables_to_plot + integral_variables_to_plot)
         plot_table_c = 1
@@ -81,6 +81,8 @@ def plot_states(plot_dict, cosmetics, fig_name, individual_state=None, fig_num=N
             ax = plt.axes(axes[counter-1])
             for jdx in range(variables_dict['xd'][name].shape[0]):
                 p = plt.plot(tgrid_ip, plot_dict['xd'][name][jdx])
+                if cosmetics['plot_bounds']:
+                    tools.plot_bounds(plot_dict, 'xd', name, jdx, tgrid_ip, p)
                 if cosmetics['plot_ref']:
                     plt.plot(plot_dict['time_grids']['ref']['ip'], plot_dict['ref']['xd'][name][jdx],
                         linestyle= '--', color = p[-1].get_color() )
@@ -244,6 +246,8 @@ def plot_lifted(plot_dict, cosmetics, fig_name, individual_state=None, fig_num=N
             ax = plt.axes(axes[counter-1])
             for jdx in range(variables_dict['xl'][name].shape[0]):
                 p = plt.plot(tgrid_ip, plot_dict['xl'][name][jdx])
+                if cosmetics['plot_bounds']:
+                    tools.plot_bounds(plot_dict, 'xl', name, jdx, tgrid_ip, p)
                 if cosmetics['plot_ref']:
                     plt.plot(plot_dict['time_grids']['ref']['ip'], plot_dict['ref']['xl'][name][jdx],
                         linestyle= '--', color = p[-1].get_color() )
@@ -433,10 +437,13 @@ def plot_algebraic_variables(plot_dict, cosmetics, fig_name):
 
     for n in range(1, number_of_nodes):
         parent = parent_map[n]
-        lambdavec = plot_dict['xa']['lambda' + str(n) + str(parent)]
+        lam_name = 'lambda' + str(n) + str(parent)
+        lambdavec = plot_dict['xa'][lam_name]
         p = plt.plot(tgrid_ip, lambdavec[0])
+        if cosmetics['plot_bounds']:
+            tools.plot_bounds(plot_dict, 'xa', lam_name, 0, tgrid_ip, p)
         if cosmetics['plot_ref']:
-            plt.plot(plot_dict['time_grids']['ref']['ip'], plot_dict['ref']['xa']['lambda' + str(n) + str(parent)][0],
+            plt.plot(plot_dict['time_grids']['ref']['ip'], plot_dict['ref']['xa'][lam_name][0],
                 linestyle= '--', color = p[-1].get_color())
         legend_names.append('lambda' + str(n) + str(parent))
     
@@ -447,6 +454,8 @@ def plot_algebraic_variables(plot_dict, cosmetics, fig_name):
                 lam_name = 'lambda{}{}'.format(kites[0], kites[1])
                 lambdavec = plot_dict['xa'][lam_name]
                 p = plt.plot(tgrid_ip, lambdavec[0])
+                if cosmetics['plot_bounds']:
+                    tools.plot_bounds(plot_dict, 'xa', lam_name, 0, tgrid_ip, p)
                 if cosmetics['plot_ref']:
                     plt.plot(
                         plot_dict['time_grids']['ref']['ip'],
@@ -459,6 +468,8 @@ def plot_algebraic_variables(plot_dict, cosmetics, fig_name):
                     lam_name = 'lambda{}{}'.format(kites[k], kites[(k+1)%len(kites)])
                     lambdavec = plot_dict['xa'][lam_name]
                     p = plt.plot(tgrid_ip, lambdavec[0])
+                    if cosmetics['plot_bounds']:
+                        tools.plot_bounds(plot_dict, 'xa', lam_name, 0, tgrid_ip, p)
                     if cosmetics['plot_ref']:
                         plt.plot(
                             plot_dict['time_grids']['ref']['ip'],
@@ -468,3 +479,4 @@ def plot_algebraic_variables(plot_dict, cosmetics, fig_name):
                     legend_names.append(lam_name)
     plt.legend(legend_names)
     plt.suptitle(fig_name)
+


### PR DESCRIPTION
Plot variable bounds in any of these plots:

```
trial.plot(['states', 'controls','algebraic_variables', 'lifted_variables'])
```

Switch on/off with:

```
options['visualization']['cosmetics']['plot_bounds'] = True
```

It ends up looking like this:

![variable_bounds_plot](https://user-images.githubusercontent.com/28870597/101023628-53e59c80-3573-11eb-9a59-97b938ffab1e.png)

Should we make it the default option? Sometimes the trajectory is so far off the bounds, that the plot becomes useless (see e.g. the plot for `l_t`)
