### PR TITLE
add 'simple' pumping phase fix option

### DIFF
--- a/awebox/ocp/discretization.py
+++ b/awebox/ocp/discretization.py
@@ -61,7 +61,7 @@ def construct_time_grids(nlp_options):
         tcoll = None
 
     # make symbolic time constants
-    if nlp_options['phase_fix']:
+    if nlp_options['phase_fix'] == 'single_reelout':
         tfsym = cas.SX.sym('tfsym',2)
         nk_reelout = round(nk * nlp_options['phase_fix_reelout'])
 
@@ -77,8 +77,8 @@ def construct_time_grids(nlp_options):
 
     for k in range(nk+1):
 
-        # extract correct time constant in case of phase fix
-        if nlp_options['phase_fix']:
+        # extract correct time constant in case of single_reelout phase fix
+        if nlp_options['phase_fix'] == 'single_reelout':
             if k < nk_reelout:
                 tf = tfsym[0]
                 k0 = 0.0

--- a/awebox/ocp/performance.py
+++ b/awebox/ocp/performance.py
@@ -54,7 +54,7 @@ def get_time_period(nlp_options, V, outputs):
     n_k = nlp_options['n_k']
     pf_reelout = nlp_options['phase_fix_reelout']
 
-    if nlp_options['phase_fix']:
+    if nlp_options['phase_fix'] == 'single_reelout':
         time_period_zeroth = V['theta', 't_f',0] * round(n_k * pf_reelout)
         time_period_first = V['theta', 't_f',1] * (n_k - round(n_k * pf_reelout))
         # average over collocation nodes
@@ -209,8 +209,8 @@ def find_phase_fix_time_period_first(nlp_numerics_options, V):
     return time_period_first
 
 def find_time_period(nlp_numerics_options, V):
-    use_phase_fix = nlp_numerics_options['phase_fix']
-    if use_phase_fix:
+
+    if nlp_numerics_options['phase_fix'] == 'single_reelout':
         time_period_zeroth = find_phase_fix_time_period_zeroth(nlp_numerics_options, V)
         time_period_first = find_phase_fix_time_period_first(nlp_numerics_options, V)
 

--- a/awebox/ocp/var_bounds.py
+++ b/awebox/ocp/var_bounds.py
@@ -95,21 +95,28 @@ def assign_phase_fix_bounds(nlp_options, model, vars_lb, vars_ub, coll_flag, var
 
     n_k = nlp_options['n_k']
 
-    if name == 'dl_t' and nlp_options['phase_fix']:
+    if name == 'dl_t':
 
-        if (var_type == 'xd') and (not coll_flag):
-            if kdx == (n_k):
-                vars_lb[var_type, kdx, name] = 0.0
-                vars_ub[var_type, kdx, name] = 0.0
+        if nlp_options['phase_fix'] == 'single_reelout':
 
-            elif in_out_phase:
-                vars_lb[var_type, kdx, name] = 0.0
-                vars_ub[var_type, kdx, name] = model.variable_bounds[var_type][name]['ub']
+            if (var_type == 'xd') and (not coll_flag):
+                if kdx == (n_k):
+                    vars_lb[var_type, kdx, name] = 0.0
+                    vars_ub[var_type, kdx, name] = 0.0
+
+                elif in_out_phase:
+                    vars_lb[var_type, kdx, name] = 0.0
+                    vars_ub[var_type, kdx, name] = model.variable_bounds[var_type][name]['ub']
+                else:
+                    vars_lb[var_type, kdx, name] = model.variable_bounds[var_type][name]['lb']
+                    vars_ub[var_type, kdx, name] = 0.0
             else:
-                vars_lb[var_type, kdx, name] = model.variable_bounds[var_type][name]['lb']
-                vars_ub[var_type, kdx, name] = 0.0
-        else:
-            32. # do nothing
+                32. # do nothing
+
+        elif nlp_options['phase_fix'] == 'simple' and (kdx == 0) and (not coll_flag):
+
+            vars_lb[var_type, kdx, name] = 0.0
+            vars_ub[var_type, kdx, name] = 0.0
 
     pumping_range = nlp_options['pumping_range']
     if name == 'l_t' and (len(pumping_range) == 2) and (pumping_range[0] is not None) and (pumping_range[1] is not None):

--- a/awebox/ocp/var_struct.py
+++ b/awebox/ocp/var_struct.py
@@ -45,7 +45,7 @@ def setup_nlp_v(nlp_options, model, Collocation=None):
     direct_collocation = (nlp_options['discretization'] == 'direct_collocation')
 
     # check if phase fix and adjust theta accordingly
-    if nlp_options['phase_fix']:
+    if nlp_options['phase_fix'] == 'single_reelout':
         theta = get_phase_fix_theta(variables_dict)
     else:
         theta = variables_dict['theta']

--- a/awebox/opts/default.py
+++ b/awebox/opts/default.py
@@ -41,7 +41,7 @@ def set_default_user_options(internal_access = False):
         ('user_options',    'trajectory',  None,        'type',                  'power_cycle',      ('possible options', ['power_cycle', 'transition','mpc']), 't'),
         ('user_options',    'trajectory',  None,        'system_type',           'lift_mode',        ('possible options', ['lift_mode','drag_mode']), 't'),
         ('user_options',    'trajectory',  'lift_mode', 'windings',              3,                  ('number of windings [int]', None),'s'),
-        ('user_options',    'trajectory',  'lift_mode', 'phase_fix',             True,               ('choose True or False', [True, False]),'x'),
+        ('user_options',    'trajectory',  'lift_mode', 'phase_fix',             'single_reelout',   ('pumping_mode phase fix option', ['single_reelout', 'simple']),'x'),
         ('user_options',    'trajectory',  'lift_mode', 'max_l_t',               None,               ('set maximum main tether length', None),'s'),
         ('user_options',    'trajectory',  'lift_mode', 'pumping_range',         None,               ('set predefined pumping range (only in comb. w. phase-fix)', None),'x'),
         ('user_options',    'trajectory',  'transition','initial_trajectory',    None,               ('relative path to pickled initial trajectory', None),'x'),

--- a/awebox/tools/struct_operations.py
+++ b/awebox/tools/struct_operations.py
@@ -352,7 +352,7 @@ def calculate_tf(params, V, k):
 
     nk = params['n_k']
 
-    if params['phase_fix'] == True:
+    if params['phase_fix'] == 'single_reelout':
         if k < round(nk * params['phase_fix_reelout']):
             tf = V['theta', 't_f', 0]
         else:
@@ -366,7 +366,7 @@ def calculate_kdx(params, V, t):
 
     n_k = params['n_k']
 
-    if params['phase_fix'] == True:
+    if params['phase_fix'] == 'single_reelout':
         k_reelout = round(n_k * params['phase_fix_reelout'])
         t_reelout = k_reelout*V['theta','t_f',0]/n_k
         if t <= t_reelout:


### PR DESCRIPTION
Add new phase fix option for lift-mode where only `l_t(0) = 0` is fixed (similar to drag mode, where only dot(q)_y(0) is fixed).

Switch between phase fix options via
`options['user_options']['trajectory']['lift_mode']['phase_fix'] = 'single_reelout' / 'simple'`

The `single_reelout` option is still the default option.