### PR TITLE
Feature/profiling cleanup

### DIFF
--- a/awebox/ocp/constraints.py
+++ b/awebox/ocp/constraints.py
@@ -112,7 +112,13 @@ def get_constraints(nlp_options, V, P, Xdot, model, dae, formulation, Integral_c
             ocp_cstr_entry_list.append(cas.entry('integral', shape=integral_cstr.get_expression_list('all').shape))
 
     # Constraints structure
-    ocp_cstr_struct = cas.struct_symSX(ocp_cstr_entry_list)(ocp_cstr_list.get_expression_list('all'))
+    ocp_cstr_struct = cas.struct_symMX(ocp_cstr_entry_list)
+
+    # test constraints structure dimension with constraints list
+    struct_length = ocp_cstr_struct.shape[0]
+    vec_length = ocp_cstr_list.get_expression_list('all').shape[0]
+    test_shapes = (struct_length == vec_length)
+    assert test_shapes, f'Mismatch in dimension between constraint vector ({vec_length}) and constraint structure ({struct_length})!'
 
     return ocp_cstr_list, ocp_cstr_struct
 

--- a/awebox/ocp/discretization.py
+++ b/awebox/ocp/discretization.py
@@ -118,7 +118,7 @@ def construct_time_grids(nlp_options):
 
 def setup_nlp_cost():
 
-    cost = cas.struct_symSX([(
+    cost = cas.struct_symMX([(
         cas.entry('tracking'),
         cas.entry('u_regularisation'),
         cas.entry('xddot_regularisation'),
@@ -145,7 +145,7 @@ def setup_nlp_cost():
 def setup_nlp_p_fix(V, model):
 
     # fixed system parameters
-    p_fix = cas.struct_symSX([(
+    p_fix = cas.struct_symMX([(
         cas.entry('ref', struct=V),     # tracking reference for cost function
         cas.entry('weights', struct=model.variables)  # weights for cost function
     )])
@@ -220,7 +220,7 @@ def setup_output_structure(nlp_options, model_outputs, global_outputs):
             cas.entry('outputs', repeat = [nk], struct = model_outputs),
         )
 
-    Outputs = cas.struct_symSX([entry_tuple]
+    Outputs = cas.struct_symMX([entry_tuple]
                            + [cas.entry('final', struct=global_outputs)])
 
     return Outputs

--- a/awebox/ocp/discretization.py
+++ b/awebox/ocp/discretization.py
@@ -324,8 +324,7 @@ def discretize(nlp_options, model, formulation):
 
     # Create Integral outputs struct and function
     Integral_outputs_struct = setup_integral_output_structure(nlp_options, model.integral_outputs)
-    Integral_outputs = Integral_outputs_struct(cas.vertcat(*Integral_outputs_list))
-    Integral_outputs_fun = cas.Function('Integral_outputs_fun', [V, P], [Integral_outputs.cat])
+    Integral_outputs_fun = cas.Function('Integral_outputs_fun', [V, P], [cas.vertcat(*Integral_outputs_list)])
 
     Xdot_struct = struct_op.construct_Xdot_struct(nlp_options, model.variables_dict)
     Xdot_fun = cas.Function('Xdot_fun',[V],[Xdot])

--- a/awebox/ocp/discretization.py
+++ b/awebox/ocp/discretization.py
@@ -319,6 +319,8 @@ def discretize(nlp_options, model, formulation):
     Outputs_list.append(global_outputs_fun(V, P))
 
     # Create Outputs struct and function
+    if nlp_options['induction']['induction_model'] == 'vortex': # outputs are need for vortex constraint construction
+        Outputs_struct = Outputs_struct(cas.vertcat(*Outputs_list))
     Outputs_fun = cas.Function('Outputs_fun', [V, P], [cas.vertcat(*Outputs_list)])
 
     # Create Integral outputs struct and function

--- a/awebox/ocp/discretization.py
+++ b/awebox/ocp/discretization.py
@@ -319,14 +319,13 @@ def discretize(nlp_options, model, formulation):
     Outputs_list.append(global_outputs_fun(V, P))
 
     # Create Outputs struct and function
-    Outputs = Outputs_struct(cas.vertcat(*Outputs_list))
-    Outputs_fun = cas.Function('Outputs_fun', [V, P], [Outputs.cat])
+    Outputs_fun = cas.Function('Outputs_fun', [V, P], [cas.vertcat(*Outputs_list)])
 
     # Create Integral outputs struct and function
     Integral_outputs_struct = setup_integral_output_structure(nlp_options, model.integral_outputs)
     Integral_outputs_fun = cas.Function('Integral_outputs_fun', [V, P], [cas.vertcat(*Integral_outputs_list)])
 
-    Xdot_struct = struct_op.construct_Xdot_struct(nlp_options, model.variables_dict)
+    Xdot_struct = Xdot
     Xdot_fun = cas.Function('Xdot_fun',[V],[Xdot])
 
     # -------------------------------------------
@@ -334,7 +333,7 @@ def discretize(nlp_options, model, formulation):
     # -------------------------------------------
     ocp_cstr_list, ocp_cstr_struct = constraints.get_constraints(nlp_options, V, P, Xdot, model, dae, formulation,
         Integral_constraint_list, Collocation, Multiple_shooting, ms_z0, ms_xf,
-            ms_vars, ms_params, Outputs, time_grids)
+            ms_vars, ms_params, Outputs_struct, time_grids)
 
     return V, P, Xdot_struct, Xdot_fun, ocp_cstr_list, ocp_cstr_struct, Outputs_struct, Outputs_fun, Integral_outputs_struct, Integral_outputs_fun, time_grids, Collocation, Multiple_shooting
 

--- a/awebox/ocp/nlp.py
+++ b/awebox/ocp/nlp.py
@@ -112,7 +112,6 @@ class NLP(object):
 
         self.__g = ocp_cstr_struct(ocp_cstr_list.get_expression_list('all'))
         self.__g_fun = ocp_cstr_list.get_function(nlp_options, V, P, 'all')
-        self.__g_jacobian_fun = cas.Function('g_jacobian_fun',[V,P], [cas.jacobian(self.__g, V)])
         self.__g_bounds = {'lb': ocp_cstr_list.get_lb('all'), 'ub': ocp_cstr_list.get_ub('all')}
 
         return None
@@ -229,15 +228,6 @@ class NLP(object):
     @f_fun.setter
     def f_fun(self, value):
         awelogger.logger.warning('Cannot set f_fun object.')
-
-
-    @property
-    def g_jacobian_fun(self):
-        return [self.__g_fun, self.__g_jacobian_fun]
-
-    @g_jacobian_fun.setter
-    def g_jacobian_fun(self, value):
-        awelogger.logger.warning('Cannot set g_jacobian_fun object.')
 
     @property
     def n_k(self):


### PR DESCRIPTION
After running a profiler I removed some time-consuming dead code.

To do at later stage:
- come up with a suitable alternative with same flexibility as, but better efficiency than, big CasADi NLP structs. Constructing these is very time-consuming.
- join duplicate code in `objective.py`, `discretization.py` and `constraints.py`. (e.g. `get_coll_vars`)
- `struct_op.get_var_at_time()` etc.. is also an inefficient implementation which makes `get_coll_vars` rather slow.