### PR TITLE
update default options

### DIFF
--- a/awebox/opts/default.py
+++ b/awebox/opts/default.py
@@ -58,7 +58,7 @@ def set_default_user_options(internal_access = False):
         ('user_options',    'wind',        None,        'u_ref',                 5.,                 ('reference wind speed [m/s]', None),'s'),
         ('user_options',    'wind',        None,        'atmosphere_heightsdata', None,              ('data for the heights at this time instant', None),'s'),
         ('user_options',    'wind',        None,        'atmosphere_featuresdata',None,              ('data for the wind features at this time instant', None),'s'),
-        ('user_options',    None,          None,        'induction_model',       'actuator',         ('possible options', ['not_in_use', 'actuator']),'x'),
+        ('user_options',    None,          None,        'induction_model',       'not_in_use',         ('possible options', ['not_in_use', 'actuator']),'x'),
         ('user_options',    None,          None,        'kite_standard',         None,               ('possible options',None),'x'),
         ('user_options',    None,          None,        'atmosphere',            'isa',              ('possible options', ['isa', 'uniform']),'x'),
         ('user_options',    None,          None,        'tether_model',          'default',          ('possible options',['default']),'x'),
@@ -102,7 +102,7 @@ def set_default_options(default_user_options, help_options):
         ('params', 'model_bounds', None, 'coeff_compromised_max', np.array([1.5, 60 * np.pi / 180.]), ('include a bound on dcoeff', None), 's'),
         ('params', 'model_bounds', None, 'coeff_compromised_min', np.array([0., -60 * np.pi / 180.]), ('include a bound on dcoeff', None), 's'),
         ('model', 'aero', 'three_dof', 'dcoeff_compromised_factor', 1., ('???', None), 's'),
-        ('model', 'aero', None,         'lift_aero_force',      True,        ('lift the aero force into the decision variables', [True, False]), 'x'),
+        ('model', 'aero', None,         'lift_aero_force',      False,        ('lift the aero force into the decision variables', [True, False]), 'x'),
         ('params','aero', None,         'turbine_efficiency',   0.75,        ('combined drag-mode propeller and generator efficiency', None), 's'),
 
         ('model', 'aero', None,         'induction_comparison',     [],     ('which induction models should we include for comparison', ['act', 'vor']), 'x'),
@@ -176,7 +176,7 @@ def set_default_options(default_user_options, help_options):
         ('model',   'tether', None,         'use_wound_tether',     True,       ('include the mass of the wound tether in the system energy calculation', [True, False]),'x'),
         ('model',   'tether', None,         'wound_tether_safety_factor', 1.1,  ('wound tether safety factor', None),'x'),
         ('model',   'tether', None,         'top_mass_alloc_frac',  0.5,        ('where to make a cut on a tether segment, in order to allocate tether mass to neighbor nodes, as fraction of segment length, measured from top', None), 'x'),
-        ('model',   'tether', None,         'lift_tether_force',    True,       ('lift the tether force into the decision variables', [True, False]), 'x'),
+        ('model',   'tether', None,         'lift_tether_force',    False,       ('lift the tether force into the decision variables', [True, False]), 'x'),
 
         #### system bounds and limits (physical)
         ('model',  'system_bounds', 'theta',       'diam_t',       [1.0e-3, 1.0e-1],                                                                ('main tether diameter bounds [m]', None),'x'),
@@ -277,7 +277,7 @@ def set_default_options(default_user_options, help_options):
         ('nlp',  None,               None,  'discretization',      'direct_collocation',   ('possible options', ['direct_collocation']),'x'),
         ('nlp',  'collocation',      None, 'd',                    4,                      ('degree of lagrange polynomials inside collocation interval [int]', None),'t'),
         ('nlp',  'collocation',      None, 'scheme',               'radau',                ('collocation scheme', ['radau','legendre']),'x'),
-        ('nlp',  'collocation',      None, 'u_param',              'zoh',                  ('control parameterization in collocation interval', ['poly','zoh']),'x'),
+        ('nlp',  'collocation',      None, 'u_param',              'poly',                  ('control parameterization in collocation interval', ['poly','zoh']),'x'),
         ('nlp',  'collocation',      None, 'name_constraints',     False,                  ('names nlp collocation constraints according to the extended model constraint. slow, but useful when debugging licq problems with the health check', [True, False]), 't'),
         ('nlp',  None,               None, 'phase_fix_reelout',    0.7,                    ('time fraction of reel-out phase', None),'x'),
         ('nlp',  None,               None, 'pumping_range',        [None, None],           ('set predefined pumping range (only in comb. w. phase-fix)', None),'x'),
@@ -301,7 +301,7 @@ def set_default_options(default_user_options, help_options):
 
         ### solver options
         # todo: embed other solvers
-        ('solver',  None,   None,   'linear_solver',        'ma57',     ('which linear solver to use', ['mumps', 'ma57']),'x'),
+        ('solver',  None,   None,   'linear_solver',        'mumps',     ('which linear solver to use', ['mumps', 'ma57']),'x'),
         ('solver',  None,   None,   'hessian_approximation',False,      ('use a limited-memory hessian approximation instead of the exact Newton hessian', [True, False]),'x'),
         ('solver',  None,   None,   'max_iter',             2000,       ('maximum ipopt iterations [int]', None),'x'),
         ('solver',  None,   None,   'max_cpu_time',         1.e4,       ('maximum cpu time (seconds) ipopt can spend in one stage of the homotopy', None), 'x'),

--- a/awebox/opts/default.py
+++ b/awebox/opts/default.py
@@ -218,12 +218,6 @@ def set_default_options(default_user_options, help_options):
 
         #### scaling
         ('model',  'scaling', 'xd',     'l_t',      500.,     ('main tether natural length [m]', None),'x'),
-        ('model',  'scaling', 'theta',  'l_i',      100.,     ('intermediate tether natural length [m]', None),'x'),
-        ('model',  'scaling', 'theta',  'l_s',      50.,      ('secondary tether natural length [m]', None),'x'),
-        ('model',  'scaling', 'theta',  'l_c',      100.,     ('cross-tether natural length [m]', None),'x'),
-        ('model',  'scaling', 'theta',  'diam_t',   5e-3,     ('main tether natural diameter [m]', None),'x'),
-        ('model',  'scaling', 'theta',  'diam_s',   5e-3,     ('secondary tether natural diameter [m]', None),'x'),
-        ('model',  'scaling', 'theta',  'diam_c',   5e-3,     ('cross-tether natural diameter [m]', None),'x'),
         ('model',  'scaling', 'xl',     'a',        1.0,      ('induction factor [-]', None),'x'),
         ('model',  'scaling', 'other',  'g',	    9.81,     ('acceleration to use for scaling [m/s^2]', None), 'x'),
         ('model',  'scaling', 'xd',     'kappa',    1e1,      ('generator braking parameter [m]', None),'x'),
@@ -337,6 +331,13 @@ def set_default_options(default_user_options, help_options):
         ('solver',  'initialization', None, 'max_cone_angle_single',10.,        ('maximum allowed cone angle allowed in initial guess, for single-kite scenarios [deg]', None),'x'),
         ('solver',  'initialization', None, 'landing_velocity',     22.,        ('initial guess for average reel in velocity during the landing [m/s]', None),'x'),
         ('solver',  'initialization', None, 'clockwise_rotation_about_xhat', True,    ('True: if the kites rotate clockwise about xhat, False: if the kites rotate counter-clockwise about xhat', [True, False]), 'x'),
+
+        ('solver',  'initialization', 'theta',  'l_i',      100.,     ('intermediate tether initialization [m]', None),'x'),
+        ('solver',  'initialization', 'theta',  'l_s',      50.,      ('secondary tether initialization [m]', None),'x'),
+        ('solver',  'initialization', 'theta',  'l_c',      100.,     ('cross-tether initialization [m]', None),'x'),
+        ('solver',  'initialization', 'theta',  'diam_t',   5e-3,     ('main tether diameter initialization [m]', None),'x'),
+        ('solver',  'initialization', 'theta',  'diam_s',   5e-3,     ('secondary tether diameter initialization [m]', None),'x'),
+        ('solver',  'initialization', 'theta',  'diam_c',   5e-3,     ('cross-tether diameter initialization [m]', None),'x'),
 
         ('solver',   'tracking',       None,   'stagger_distance',      0.1,       ('distance between tracking trajectory and initial guess [m]', None),'x'),
         ('solver',   'cost_factor',    None,   'power',                 1.,       ('factor used in generating the power cost [-]', None), 'x'),

--- a/awebox/opts/funcs.py
+++ b/awebox/opts/funcs.py
@@ -218,7 +218,7 @@ def build_solver_options(options, help_options, user_options, options_tree, arch
         options_tree.append(('solver', None, None, 'tol_hippo',       1e-4,        ('tolerance for interior point homotop parameter for hippo strategy [float]', None),'x'))
 
     # initialize theta params with standard scaling length or fixed length
-    initialization_theta = options['model']['scaling']['theta']
+    initialization_theta = options['solver']['initialization']['theta']
     for param in list(user_options['trajectory']['fixed_params'].keys()):
         initialization_theta[param] = user_options['trajectory']['fixed_params'][param]
     for param in list(fixed_params.keys()):

--- a/awebox/opts/model_funcs.py
+++ b/awebox/opts/model_funcs.py
@@ -811,8 +811,10 @@ def build_wound_tether_length_options(options, options_tree, fixed_params):
     q_scaling = 1.
     options_tree.append(('model', 'scaling', 'xd', 'q', q_scaling, ('descript', None), 'x'))
 
+    initialization_theta = options['solver']['initialization']['theta']
+    for param in initialization_theta.keys():
+        options_tree.append(('model', 'scaling', 'theta', param, options['solver']['initialization']['theta'][param], ('descript', None), 'x'))
     options_tree.append(('model', 'scaling', 'theta', 't_f', cas.DM(1.0), ('descript', None), 'x'))
-
 
     return options_tree, fixed_params
 
@@ -981,9 +983,9 @@ def generate_lambda_scaling_tree(options, options_tree, lambda_scaling, architec
     layers = architecture.layers
 
     # extract length scaling information
-    l_s_scaling = options['model']['scaling']['theta']['l_s']
+    l_s_scaling = options['solver']['initialization']['theta']['l_s']
     l_t_scaling = options['model']['scaling']['xd']['l_t']
-    l_i_scaling = options['model']['scaling']['theta']['l_i']
+    l_i_scaling = options['solver']['initialization']['theta']['l_i']
 
     #  secondary tether scaling
     tension_main = lambda_scaling * l_t_scaling

--- a/test/reg/test_trials.py
+++ b/test/reg/test_trials.py
@@ -201,6 +201,9 @@ def generate_options_dict():
     actuator_qaxi_options['model']['aero']['overwrite']['beta_max_deg'] = 20.
     actuator_qaxi_options['model']['aero']['overwrite']['beta_min_deg'] = -20.
     actuator_qaxi_options['model']['model_bounds']['tether_stress']['scaling'] = 10.
+    actuator_qaxi_options['model']['tether']['lift_tether_force'] = True
+    actuator_qaxi_options['model']['aero']['lift_aero_force'] = True
+    actuator_qaxi_options['nlp']['collocation']['u_param'] = 'zoh'
     actuator_qaxi_options['solver']['cost']['fictitious'][0] = 1.e3
     actuator_qaxi_options['nlp']['n_k'] = 15
 
@@ -234,6 +237,9 @@ def generate_options_dict():
     vortex_options['model']['aero']['vortex']['representation'] = 'alg'
     vortex_options['model']['aero']['overwrite']['alpha_max_deg'] = 20.
     vortex_options['model']['aero']['overwrite']['alpha_min_deg'] = -20.
+    vortex_options['model']['tether']['lift_tether_force'] = True
+    vortex_options['model']['aero']['lift_aero_force'] = True
+    vortex_options['nlp']['collocation']['u_param'] = 'zoh'
 
     dual_kite_tracking_options = copy.deepcopy(dual_kite_6_dof_options)
     dual_kite_tracking_options['user_options']['trajectory']['type'] = 'tracking'


### PR DESCRIPTION
- Closes #79 
- initialize `theta` and derive scaling from there instead of the other way around.
- Rework examples so that the are more instructive and provide a consistent overview of functionality.