### PR TITLE
Penalize Pmax

### DIFF
--- a/awebox/mdl/dynamics.py
+++ b/awebox/mdl/dynamics.py
@@ -138,6 +138,9 @@ def make_dynamics(options, atmos, wind, parameters, architecture):
     outputs, rotation_cstr = rotation_inequality(options, system_variables['SI'], parameters, architecture, outputs)
     cstr_list.append(rotation_cstr)
 
+    P_max_cstr = P_max_inequality(options, system_variables['SI'], power, parameters, architecture)
+    cstr_list.append(P_max_cstr)
+
     # ----------------------------------------
     #  sanity checking
     # ----------------------------------------
@@ -565,6 +568,19 @@ def coeff_actuation_inequality(options, variables_si, parameters, architecture):
     return cstr_list
 
 
+def P_max_inequality(options, variables, power, parameters, architecture):
+
+    cstr_list = mdl_constraint.MdlConstraintList()
+
+    max_power_ineq = (power - variables['theta']['P_max'])/options['scaling']['theta']['P_max'] - parameters['theta0','model_bounds','P_max_ub']
+
+    P_max_cstr = cstr_op.Constraint(expr=max_power_ineq,
+                                name='P_max_cstr',
+                                cstr_type='ineq')
+    cstr_list.append(P_max_cstr)
+
+    return cstr_list
+
 def acceleration_inequality(options, variables):
 
     cstr_list = mdl_constraint.MdlConstraintList()
@@ -591,7 +607,6 @@ def acceleration_inequality(options, variables):
                 cstr_list.append(acc_cstr)
 
     return cstr_list
-
 
 def airspeed_inequality(options, outputs, parameters, architecture):
 

--- a/awebox/mdl/dynamics.py
+++ b/awebox/mdl/dynamics.py
@@ -573,7 +573,7 @@ def P_max_inequality(options, variables, power, parameters, architecture):
     cstr_list = mdl_constraint.MdlConstraintList()
 
     if 'P_max' in variables['theta'].keys():
-        max_power_ineq = (power - variables['theta']['P_max'])/options['scaling']['theta']['P_max'] - parameters['theta0','model_bounds','P_max_ub']
+        max_power_ineq = (power - variables['theta']['P_max'])/options['scaling']['theta']['P_max']
 
         P_max_cstr = cstr_op.Constraint(expr=max_power_ineq,
                                     name='P_max_cstr',

--- a/awebox/mdl/dynamics.py
+++ b/awebox/mdl/dynamics.py
@@ -138,12 +138,6 @@ def make_dynamics(options, atmos, wind, parameters, architecture):
     outputs, rotation_cstr = rotation_inequality(options, system_variables['SI'], parameters, architecture, outputs)
     cstr_list.append(rotation_cstr)
 
-    dcoeff_cstr = dcoeff_actuation_inequality(options, system_variables['SI'], parameters, architecture)
-    cstr_list.append(dcoeff_cstr)
-
-    coeff_cstr = coeff_actuation_inequality(options, system_variables['SI'], parameters, architecture)
-    cstr_list.append(coeff_cstr)
-
     # ----------------------------------------
     #  sanity checking
     # ----------------------------------------

--- a/awebox/mdl/dynamics.py
+++ b/awebox/mdl/dynamics.py
@@ -572,12 +572,13 @@ def P_max_inequality(options, variables, power, parameters, architecture):
 
     cstr_list = mdl_constraint.MdlConstraintList()
 
-    max_power_ineq = (power - variables['theta']['P_max'])/options['scaling']['theta']['P_max'] - parameters['theta0','model_bounds','P_max_ub']
+    if 'P_max' in variables['theta'].keys():
+        max_power_ineq = (power - variables['theta']['P_max'])/options['scaling']['theta']['P_max'] - parameters['theta0','model_bounds','P_max_ub']
 
-    P_max_cstr = cstr_op.Constraint(expr=max_power_ineq,
-                                name='P_max_cstr',
-                                cstr_type='ineq')
-    cstr_list.append(P_max_cstr)
+        P_max_cstr = cstr_op.Constraint(expr=max_power_ineq,
+                                    name='P_max_cstr',
+                                    cstr_type='ineq')
+        cstr_list.append(P_max_cstr)
 
     return cstr_list
 

--- a/awebox/mdl/system.py
+++ b/awebox/mdl/system.py
@@ -182,9 +182,16 @@ def generate_structure(options, architecture):
         system_derivatives.extend([('d'+system_states[i][0], system_states[i][1])])
 
     # system parameters
-    system_parameters = [('l_s', (1, 1)), ('l_i', (1, 1)), ('diam_s', (1, 1)), ('diam_t', (1, 1)), ('t_f',(1,1))]
+    system_parameters = [('diam_t', (1, 1)), ('t_f',(1,1))]
+
+    if len(architecture.kite_nodes) > 1:
+        system_parameters += [('l_s', (1, 1)), ('diam_s', (1, 1))]
+    if len(architecture.layer_nodes) > 1:
+        system_parameters += [('l_i', (1, 1)), ('diam_i', (1, 1))]
+
     if options['tether']['use_wound_tether']:
         system_parameters += [('l_t_full', (1, 1))]
+    system_parameters += [('P_max', (1, 1))] # max power
 
 
     # add cross-tether lengths and diameters

--- a/awebox/mdl/system.py
+++ b/awebox/mdl/system.py
@@ -191,7 +191,9 @@ def generate_structure(options, architecture):
 
     if options['tether']['use_wound_tether']:
         system_parameters += [('l_t_full', (1, 1))]
-    system_parameters += [('P_max', (1, 1))] # max power
+    
+    if 'P_max' in options['system_bounds']['theta'].keys():
+        system_parameters += [('P_max', (1, 1))] # max power
 
 
     # add cross-tether lengths and diameters

--- a/awebox/ocp/discretization.py
+++ b/awebox/ocp/discretization.py
@@ -137,7 +137,8 @@ def setup_nlp_cost():
         cas.entry('nominal_landing'),
         cas.entry('compromised_battery'),
         cas.entry('transition'),
-        cas.entry('slack')
+        cas.entry('slack'),
+        cas.entry('P_max')
     )])
 
     return cost

--- a/awebox/ocp/objective.py
+++ b/awebox/ocp/objective.py
@@ -286,7 +286,10 @@ def find_power_cost(nlp_options, V, P, Integral_outputs):
     else:
         average_power = Integral_outputs['int_out',-1,'e'] / time_period
 
-    power_cost = P['cost', 'power'] * (-1.) * average_power * (P['cost', 'P_max'] + (1-P['cost', 'P_max']) / V['theta', 'P_max'])
+    if nlp_options['cost']['P_max']:
+        power_cost = P['cost', 'power'] * (-1.) * average_power * (P['cost', 'P_max'] + (1-P['cost', 'P_max']) / V['theta', 'P_max'])
+    else:
+        power_cost = P['cost', 'power'] * (-1.) * average_power
 
     return power_cost
 

--- a/awebox/ocp/objective.py
+++ b/awebox/ocp/objective.py
@@ -286,7 +286,7 @@ def find_power_cost(nlp_options, V, P, Integral_outputs):
     else:
         average_power = Integral_outputs['int_out',-1,'e'] / time_period
 
-    power_cost = P['cost', 'power'] * (-1.) * average_power / V['theta', 'P_max']
+    power_cost = P['cost', 'power'] * (-1.) * average_power * (P['cost', 'P_max'] + (1-P['cost', 'P_max']) / V['theta', 'P_max'])
 
     return power_cost
 

--- a/awebox/ocp/objective.py
+++ b/awebox/ocp/objective.py
@@ -286,7 +286,7 @@ def find_power_cost(nlp_options, V, P, Integral_outputs):
     else:
         average_power = Integral_outputs['int_out',-1,'e'] / time_period
 
-    power_cost = P['cost', 'power'] * (-1.) * average_power
+    power_cost = P['cost', 'power'] * (-1.) * average_power / V['theta', 'P_max']
 
     return power_cost
 
@@ -304,6 +304,7 @@ def find_power_derivative_cost(nlp_options, V, P, Xdot, Integral_outputs):
         power_derivative_sq = 0.0
         for k in range(nk_start, nk_stop):
             for j in range(nlp_options['collocation']['d']):
+                # TODO: fix scaling
                 lam = V['coll_var', k, j, 'z', 'lambda10']
                 dlam = Xdot['coll_z', k, j, 'lambda10']
                 l_t = V['coll_var', k, j, 'x', 'l_t']

--- a/awebox/ocp/objective.py
+++ b/awebox/ocp/objective.py
@@ -287,7 +287,8 @@ def find_power_cost(nlp_options, V, P, Integral_outputs):
         average_power = Integral_outputs['int_out',-1,'e'] / time_period
 
     if nlp_options['cost']['P_max']:
-        power_cost = P['cost', 'power'] * (-1.) * average_power * (P['cost', 'P_max'] + (1.0 - P['cost', 'P_max']) / V['theta', 'P_max'])
+        max_power_cost = (1.0 - P['cost', 'P_max']) * V['theta', 'P_max']
+        power_cost = P['cost', 'power'] * (-1.) * average_power + max_power_cost
     else:
         power_cost = P['cost', 'power'] * (-1.) * average_power
 

--- a/awebox/ocp/objective.py
+++ b/awebox/ocp/objective.py
@@ -287,7 +287,7 @@ def find_power_cost(nlp_options, V, P, Integral_outputs):
         average_power = Integral_outputs['int_out',-1,'e'] / time_period
 
     if nlp_options['cost']['P_max']:
-        power_cost = P['cost', 'power'] * (-1.) * average_power * (P['cost', 'P_max'] + (1-P['cost', 'P_max']) / V['theta', 'P_max'])
+        power_cost = P['cost', 'power'] * (-1.) * average_power * (P['cost', 'P_max'] + (1.0 - P['cost', 'P_max']) / V['theta', 'P_max'])
     else:
         power_cost = P['cost', 'power'] * (-1.) * average_power
 

--- a/awebox/opti/preparation.py
+++ b/awebox/opti/preparation.py
@@ -177,6 +177,13 @@ def set_initial_bounds(nlp, model, formulation, options, V_init):
     V_bounds['lb']['theta', 't_f'] = initial_scaled_time
     V_bounds['ub']['theta', 't_f'] = initial_scaled_time
 
+    if 'P_max' in model.variables_dict['theta'].keys():
+        if options['cost']['P_max'][0] == 1.0:
+            V_bounds['lb']['theta', 'P_max'] = 1e3
+            V_bounds['ub']['theta', 'P_max'] = 1e3
+            nlp.V_bounds['lb']['theta', 'P_max'] = 1e3
+            nlp.V_bounds['ub']['theta', 'P_max'] = 1e3
+
     # set fictitious forces bounds
     for name in list(model.variables_dict['u'].keys()):
         if 'fict' in name:

--- a/awebox/opti/preparation.py
+++ b/awebox/opti/preparation.py
@@ -93,7 +93,7 @@ def set_p_fix_num(V_ref, nlp, model, V_init, options):
     p_fix_num['p', 'weights'] = 1.0e-8
 
     # weights and references
-    for variable_type in set(model.variables.keys()) - set(['xdot']):
+    for variable_type in set(model.variables.keys()):
         for name in struct_op.subkeys(model.variables, variable_type):
             # set weights
             var_name, _ = struct_op.split_name_and_node_identifier(name)

--- a/awebox/opts/default.py
+++ b/awebox/opts/default.py
@@ -355,6 +355,7 @@ def set_default_options(default_user_options, help_options):
         ('solver',   'weights',        None,   'lambda',                1.,         ('optimization weight for all lambda variables [-]', None),'x'),
         ('solver',   'weights',        None,   'a',                     1e-3,       ('optimization weight for lifted variable a [-]', None),'x'),
         ('solver',   'weights',        None,   'dkappa',                1e1,        ('optimization weight for control variable dkappa [-]', None),'s'),
+        ('solver',   'weights',        None,   'P_max',                 0.0,        ('optimization weight for parameter variable P_max [-]', None),'s'),
 
         ('solver',   'weights_overwrite', None,   'dddl_t',         None,       ('optimization weight for control variable dddl_t [-]', None),'s'),
         ('solver',   'weights_overwrite', None,   'ddl_t',          None,       ('optimization weight for control variable ddl_t [-]', None), 's'),

--- a/awebox/opts/default.py
+++ b/awebox/opts/default.py
@@ -94,10 +94,6 @@ def set_default_options(default_user_options, help_options):
 
         ## aero model
         ('model', 'aero', None,         'aero_coeff_ref_velocity',     'eff',           ('specifies which velocity is used to define the stability derivatives: the APParent velocity (as for wind-tunnel or computer generated derivatives), or the EFFective velocity (as for free-flight measurements using a Pitot-tube)', ['app', 'eff']), 'x'),
-        ('model', 'aero', 'three_dof',  'coeff_max',    [2., 80.0 * np.pi / 180.],      ('maximum coefficients in roll-control model', None),'x'),
-        ('model', 'aero', 'three_dof',  'coeff_min',    [0., -80.0 * np.pi / 180.],     ('minimum coefficients in roll-control model', None),'x'),
-        ('model', 'aero', 'three_dof',  'dcoeff_max',   [5., 80. * np.pi / 180],        ('include a bound on dcoeff', None), 'x'),
-        ('model', 'aero', 'three_dof',  'dcoeff_min',   [-5., -80. * np.pi / 180],      ('include a bound on dcoeff', None), 'x'),
         ('params', 'model_bounds', None, 'coeff_compromised_max', np.array([1.5, 60 * np.pi / 180.]), ('include a bound on dcoeff', None), 's'),
         ('params', 'model_bounds', None, 'coeff_compromised_min', np.array([0., -60 * np.pi / 180.]), ('include a bound on dcoeff', None), 's'),
         ('model', 'aero', 'three_dof', 'dcoeff_compromised_factor', 1., ('???', None), 's'),
@@ -196,6 +192,9 @@ def set_default_options(default_user_options, help_options):
         ('model',  'system_bounds', 'u',           'dkappa',       [-1000.0, 1000.0],                                                               ('generator braking constant [kg/m/s]', None),'x'),
         ('model',  'system_bounds', 'u',           'dddl_t',       [-100.0, 100.0],                                                               ('main tether jerk bounds', None),'x'),
 
+        ('model',  'system_bounds', 'x',          'coeff',        [np.array([0., -80.0 * np.pi / 180.]), np.array([2., 80.0 * np.pi / 180.])],   ('coeff bounds [-]', None),'s'),
+        ('model',  'system_bounds', 'u',          'dcoeff',       [np.array([-5., -80. * np.pi / 180]), np.array([5., 80. * np.pi / 180])],   ('dcoeff bounds [-]', None),'s'),
+
         #### model bounds (range of validity)
         ('model',   'model_bounds', 'wound_tether_length', 'include',        True,      ('include constraint that total main tether length include the unrolled main tether length in constraints', [True, False]), 'x'),
         ('model',   'model_bounds', 'tether_stress', 'include',              True,      ('include tether stress inequality in constraints', [True, False]),'x'),
@@ -216,8 +215,6 @@ def set_default_options(default_user_options, help_options):
         ('params',  'model_bounds', None,           'rot_angles',            np.array([80.0*np.pi/180., 80.0*np.pi/180., 160.0*np.pi/180.0]), ('[roll, pitch, yaw] - [rad]', None), 's'),
         ('params',  'model_bounds', None,           'rot_angles_cross',      np.array([80.0*np.pi/180., 80.0*np.pi/180., 85.0*np.pi/180.0]), ('[roll, pitch, yaw] - [rad]', None), 's'),
         ('params',  'model_bounds', None,           'span_angle',            45.0*np.pi/180., ('[max. angle between span and wing-tip cross-tether] - [rad]', None), 's'),
-        ('model',   'model_bounds', 'dcoeff_actuation', 'include',          True,       ('include a bound on dcoeff', None), 'x'),
-        ('model',   'model_bounds', 'coeff_actuation',  'include',          True,       ('include a bound on coeff', None), 'x'),
 
         #### scaling
         ('model',  'scaling', 'x',     'l_t',      500.,     ('main tether natural length [m]', None),'x'),

--- a/awebox/opts/default.py
+++ b/awebox/opts/default.py
@@ -356,6 +356,7 @@ def set_default_options(default_user_options, help_options):
         ('solver',   'weights',        None,   'a',                     1e-3,       ('optimization weight for lifted variable a [-]', None),'x'),
         ('solver',   'weights',        None,   'dkappa',                1e1,        ('optimization weight for control variable dkappa [-]', None),'s'),
         ('solver',   'weights',        None,   'P_max',                 0.0,        ('optimization weight for parameter variable P_max [-]', None),'s'),
+        ('solver',   'weights',        None,   'ddq',                   1e3,        ('optimization weight for all ddq variables [-]', None),'s'),
 
         ('solver',   'weights_overwrite', None,   'dddl_t',         None,       ('optimization weight for control variable dddl_t [-]', None),'s'),
         ('solver',   'weights_overwrite', None,   'ddl_t',          None,       ('optimization weight for control variable ddl_t [-]', None), 's'),
@@ -363,7 +364,7 @@ def set_default_options(default_user_options, help_options):
         ('solver',  'cost',             'tracking',             0,  1e-1,       ('starting cost for tracking', None),'s'),
         ('solver',  'cost',             'u_regularisation',     0,  1e-4,       ('starting cost for u_regularisation', None),'s'),
         ('solver',  'cost',             'slack',                0,  1e-2,       ('starting cost for slack penalization', None), 's'),
-        ('solver',  'cost',             'xdot_regularisation', 0,  1e-1,       ('starting cost for xdot regularisation', None),'s'),
+        ('solver',  'cost',             'xdot_regularisation', 0,   1e-5,       ('starting cost for xdot regularisation', None),'s'),
         ('solver',  'cost',             'theta_regularisation', 0,  1e-2,       ('starting cost for theta', None), 's'),
 
         ('solver',  'cost',             'gamma',            0,      0.,         ('starting cost for gamma', None),'s'),

--- a/awebox/opts/default.py
+++ b/awebox/opts/default.py
@@ -281,7 +281,7 @@ def set_default_options(default_user_options, help_options):
         ('nlp',  'parallelization',  None, 'type',                 'openmp',               ('parallellization type', None),'t'),
         ('nlp',  None,               None, 'slack_constraints',    False,                  ('slack path constraints', (True, False)),'t'),
         ('nlp',  None,               None, 'constraint_scale',     1.,                     ('value with which to scale all constraints, to improve kkt matrix conditioning', None), 't'),
-
+        ('nlp',  'cost',             None, 'P_max',                False,                  ('divide power output by peak power in cost function', None), 's'),
 
         ### Multiple shooting integrator options
         ('nlp',  'integrator',       None, 'type',                 'collocation',          ('integrator type', ('idas', 'collocation')),'t'),

--- a/awebox/opts/default.py
+++ b/awebox/opts/default.py
@@ -380,6 +380,7 @@ def set_default_options(default_user_options, help_options):
         ('solver',  'cost',             'nominal_landing',  0,      0,          ('starting cost for nominal_landing', None),'s'),
         ('solver',  'cost',             'compromised_battery',  0,  0,          ('starting cost for compromised_battery', None),'s'),
         ('solver',  'cost',             'transition',       0,      0,          ('starting cost for transition', None),'s'),
+        ('solver',  'cost',             'P_max',            0,      1,          ('starting cost for P_max', None),'s'),
 
         ('solver',  'cost',             'tracking',         1,      1.e-6,         ('update cost for tracking', None),'s'),
         ('solver',  'cost',             'gamma',            1,      1e3,        ('update cost for gamma', None),'s'),

--- a/awebox/opts/funcs.py
+++ b/awebox/opts/funcs.py
@@ -204,7 +204,6 @@ def build_nlp_options(options, help_options, user_options, options_tree, archite
 
     if options['nlp']['cost']['P_max']:
         _, _, _, power = model_funcs.get_suggested_lambda_energy_power_scaling(options, architecture)
-        options_tree.append(('params', 'model_bounds', None, 'P_max_ub', 0.0, ('????', None), 'x'))
         options_tree.append(('model', 'system_bounds', 'theta', 'P_max', [1e-3, cas.inf], ('????', None), 'x'))
         options_tree.append(('model', 'scaling', 'theta', 'P_max', power, ('????', None), 'x'))
         options_tree.append(('solver', 'initialization', 'theta', 'P_max', power, ('????', None), 'x'))

--- a/awebox/opts/funcs.py
+++ b/awebox/opts/funcs.py
@@ -203,8 +203,12 @@ def build_nlp_options(options, help_options, user_options, options_tree, archite
     options_tree.append(('nlp', 'mpc', None, 'terminal_point_constr', options['formulation']['mpc']['terminal_point_constr'], ('????', None), 'x'))
 
     if options['nlp']['cost']['P_max']:
+        _, _, _, power = model_funcs.get_suggested_lambda_energy_power_scaling(options, architecture)
         options_tree.append(('params', 'model_bounds', None, 'P_max_ub', 0.0, ('????', None), 'x'))
         options_tree.append(('model', 'system_bounds', 'theta', 'P_max', [1e-3, cas.inf], ('????', None), 'x'))
+        options_tree.append(('model', 'scaling', 'theta', 'P_max', power, ('????', None), 'x'))
+        options_tree.append(('solver', 'initialization', 'theta', 'P_max', power, ('????', None), 'x'))
+
     # else:
     #     _, _, _, power = model_funcs.get_suggested_lambda_energy_power_scaling(options, architecture)
     #     options_tree.append(('params', 'model_bounds', None, 'P_max_ub', 0.0, ('????', None), 'x'))

--- a/awebox/opts/funcs.py
+++ b/awebox/opts/funcs.py
@@ -305,8 +305,8 @@ def build_formulation_options(options, help_options, user_options, options_tree,
     options_tree.append(
         ('formulation', 'collocation', None, 'scheme', options['nlp']['collocation']['scheme'], ('???', None), 'x'))
     if int(user_options['system_model']['kite_dof']) == 3:
-        coeff_max = np.array(options['model']['aero']['three_dof']['coeff_max'])
-        coeff_min = np.array(options['model']['aero']['three_dof']['coeff_min'])
+        coeff_max = options['model']['system_bounds']['x']['coeff'][1]
+        coeff_min = options['model']['system_bounds']['x']['coeff'][0]
         battery_model_parameters = load_battery_parameters(options['user_options']['kite_standard'], coeff_max, coeff_min)
         for name in list(battery_model_parameters.keys()):
             if options['formulation']['compromised_landing']['battery'][name] is None:

--- a/awebox/opts/funcs.py
+++ b/awebox/opts/funcs.py
@@ -201,6 +201,13 @@ def build_nlp_options(options, help_options, user_options, options_tree, archite
 
     options_tree.append(('nlp', 'mpc', None, 'terminal_point_constr', options['formulation']['mpc']['terminal_point_constr'], ('????', None), 'x'))
 
+    if options['nlp']['cost']['P_max']:
+        options_tree.append(('params', 'model_bounds', None, 'P_max_ub', 0.0, ('????', None), 'x'))
+        options_tree.append(('model', 'system_bounds', 'theta', 'P_max', [1e-3, cas.inf], ('????', None), 'x'))
+    else:
+        options_tree.append(('params', 'model_bounds', None, 'P_max_ub', 1e6, ('????', None), 'x'))
+        options_tree.append(('model', 'system_bounds', 'theta', 'P_max', [1.0, 1.0], ('????', None), 'x'))
+
     return options_tree, phase_fix
 
 

--- a/awebox/opts/funcs.py
+++ b/awebox/opts/funcs.py
@@ -205,10 +205,10 @@ def build_nlp_options(options, help_options, user_options, options_tree, archite
     if options['nlp']['cost']['P_max']:
         options_tree.append(('params', 'model_bounds', None, 'P_max_ub', 0.0, ('????', None), 'x'))
         options_tree.append(('model', 'system_bounds', 'theta', 'P_max', [1e-3, cas.inf], ('????', None), 'x'))
-    else:
-        _, _, _, power = model_funcs.get_suggested_lambda_energy_power_scaling(options, architecture)
-        options_tree.append(('params', 'model_bounds', None, 'P_max_ub', 1e9, ('????', None), 'x'))
-        options_tree.append(('model', 'system_bounds', 'theta', 'P_max', [power, power], ('????', None), 'x'))
+    # else:
+    #     _, _, _, power = model_funcs.get_suggested_lambda_energy_power_scaling(options, architecture)
+    #     options_tree.append(('params', 'model_bounds', None, 'P_max_ub', 0.0, ('????', None), 'x'))
+    #     options_tree.append(('model', 'system_bounds', 'theta', 'P_max', [power, power], ('????', None), 'x'))
 
     return options_tree, phase_fix
 

--- a/awebox/opts/funcs.py
+++ b/awebox/opts/funcs.py
@@ -25,6 +25,7 @@
 
 import numpy as np
 import copy
+import casadi as cas
 from awebox.logger.logger import Logger as awelogger
 import awebox.opts.model_funcs as model_funcs
 import awebox.tools.print_operations as print_op
@@ -206,7 +207,7 @@ def build_nlp_options(options, help_options, user_options, options_tree, archite
         options_tree.append(('model', 'system_bounds', 'theta', 'P_max', [1e-3, cas.inf], ('????', None), 'x'))
     else:
         _, _, _, power = model_funcs.get_suggested_lambda_energy_power_scaling(options, architecture)
-        options_tree.append(('params', 'model_bounds', None, 'P_max_ub', 1e6, ('????', None), 'x'))
+        options_tree.append(('params', 'model_bounds', None, 'P_max_ub', 1e9, ('????', None), 'x'))
         options_tree.append(('model', 'system_bounds', 'theta', 'P_max', [power, power], ('????', None), 'x'))
 
     return options_tree, phase_fix

--- a/awebox/opts/funcs.py
+++ b/awebox/opts/funcs.py
@@ -205,8 +205,9 @@ def build_nlp_options(options, help_options, user_options, options_tree, archite
         options_tree.append(('params', 'model_bounds', None, 'P_max_ub', 0.0, ('????', None), 'x'))
         options_tree.append(('model', 'system_bounds', 'theta', 'P_max', [1e-3, cas.inf], ('????', None), 'x'))
     else:
+        _, _, _, power = model_funcs.get_suggested_lambda_energy_power_scaling(options, architecture)
         options_tree.append(('params', 'model_bounds', None, 'P_max_ub', 1e6, ('????', None), 'x'))
-        options_tree.append(('model', 'system_bounds', 'theta', 'P_max', [1.0, 1.0], ('????', None), 'x'))
+        options_tree.append(('model', 'system_bounds', 'theta', 'P_max', [power, power], ('????', None), 'x'))
 
     return options_tree, phase_fix
 

--- a/awebox/opts/model_funcs.py
+++ b/awebox/opts/model_funcs.py
@@ -959,7 +959,7 @@ def get_gravity_ref(options):
 
 def build_lambda_e_power_scaling(options, options_tree, fixed_params, architecture):
 
-    lambda_scaling, energy_scaling, power_cost = get_suggested_lambda_energy_power_scaling(options, architecture)
+    lambda_scaling, energy_scaling, power_cost, power = get_suggested_lambda_energy_power_scaling(options, architecture)
 
     if options['model']['scaling_overwrite']['lambda_tree']['include']:
         options_tree = generate_lambda_scaling_tree(options= options, options_tree= options_tree, lambda_scaling= lambda_scaling, architecture = architecture)
@@ -969,6 +969,9 @@ def build_lambda_e_power_scaling(options, options_tree, fixed_params, architectu
     options_tree.append(('model', 'scaling', 'x', 'e', energy_scaling, ('scaling of the energy', None),'x'))
 
     options_tree.append(('solver', 'cost', 'power', 1, power_cost, ('update cost for power', None),'x'))
+
+    options_tree.append(('model', 'scaling', 'theta', 'P_max', power, ('Max. power scaling factor', None),'x'))
+    options_tree.append(('solver', 'initialization', 'theta', 'P_max', power, ('Max. power initialization', None),'x'))
 
     return options_tree, fixed_params
 
@@ -1044,7 +1047,7 @@ def get_suggested_lambda_energy_power_scaling(options, architecture):
         power_cost_factor = options['solver']['cost_factor']['power']
         power_cost = power_cost_factor * (1. / scaled_power)  # yes, this = pcf * time_period_estimate
 
-    return lambda_scaling, energy_scaling, power_cost
+    return lambda_scaling, energy_scaling, power_cost, power
 
 
 def estimate_power(options, architecture):

--- a/awebox/pmpc.py
+++ b/awebox/pmpc.py
@@ -122,11 +122,10 @@ class Pmpc(object):
             self.__trial.nlp.V_bounds['ub']['x',-1] = np.inf
         g_ub = self.__trial.nlp.g(self.__trial.nlp.g_bounds['ub'])
         for constr in self.__trial.model.constraints_dict['inequality'].keys():
-            if constr != 'dcoeff_actuation':
-                if self.__mpc_options['u_param'] == 'poly':
-                    g_ub['path',0,:,constr] = np.inf
-                else:
-                    g_ub['path',0, constr] = np.inf
+            if self.__mpc_options['u_param'] == 'poly':
+                g_ub['path',0,:,constr] = np.inf
+            else:
+                g_ub['path',0, constr] = np.inf
         self.__trial.nlp.g_bounds['ub'] = g_ub.cat
 
         return None

--- a/awebox/trial.py
+++ b/awebox/trial.py
@@ -418,6 +418,14 @@ class Trial(object):
     def return_status_numeric(self, value):
         print('Cannot set return_status_numeric object.')
 
+    @property
+    def solution_dict(self):
+        return self.__solution_dict
+
+    @solution_dict.setter
+    def solution_dict(self, value):
+        print('Cannot set solution_dict object.')
+
 def generate_initial_state(model, V_init):
     x0 = model.struct_list['x'](0.)
     for name in list(model.struct_list['x'].keys()):

--- a/awebox/viz/visualization.py
+++ b/awebox/viz/visualization.py
@@ -38,7 +38,7 @@ import os
 
 
 import matplotlib
-matplotlib.use('Agg')
+# matplotlib.use('Agg')
 
 import matplotlib.pyplot as plt
 

--- a/awebox/viz/visualization.py
+++ b/awebox/viz/visualization.py
@@ -38,7 +38,6 @@ import os
 
 
 import matplotlib
-# matplotlib.use('Agg')
 
 import matplotlib.pyplot as plt
 

--- a/test/units/test_model.py
+++ b/test/units/test_model.py
@@ -285,7 +285,7 @@ def test_tether_moments():
         var_si['x', 'ddl_t'] = 9.49347e-13
 
     var_si['z'] = 45.024
-    var_si['theta'] = np.array([50, 100, 0.005, 0.00492276, 3.93805])
+    var_si['theta'] = np.array([0.005, 3.93805, 1])
 
     # scaled variables
     scaling = model.scaling

--- a/test/units/test_model.py
+++ b/test/units/test_model.py
@@ -285,7 +285,7 @@ def test_tether_moments():
         var_si['x', 'ddl_t'] = 9.49347e-13
 
     var_si['z'] = 45.024
-    var_si['theta'] = np.array([0.005, 3.93805, 1])
+    var_si['theta'] = np.array([0.005, 3.93805])
 
     # scaled variables
     scaling = model.scaling


### PR DESCRIPTION
Feature that changes the power cost from `- avg_power` to ` - avg_power + gamma * Pmax`, where Pmax is the (positive) peak power generated by the system. This allows the user to limit the peak power (which determines the sizing and thus cost of the electric components) rather than improve power quality (which might be of second rate importance). Of course, both features can be combined if desired.
  
Implementation: a system parameter `theta_Pmax` is added to the system and the constraint `p_current - theta_Pmax < 0` is added the the OCP.