### PR TITLE
Initialize cone angle instead of winding period

### DIFF
--- a/awebox/opts/default.py
+++ b/awebox/opts/default.py
@@ -327,7 +327,7 @@ def set_default_options(default_user_options, help_options):
         ('solver',  'initialization', None, 'interpolation_scheme', 's_curve',  ('interpolation scheme used for initial guess generation', ['s_curve', 'poly']), 'x'),
         ('solver',  'initialization', None, 'fix_tether_length',    False,      ('fix tether length for trajectory', [True, False]), 'x'),
         ('solver',  'initialization', None, 'groundspeed',          60.,        ('initial guess of kite speed (magnitude) as measured by earth-fixed observer [m/s]', None),'x'),
-        ('solver',  'initialization', None, 'winding_period',       10.,        ('initial guess of reasonable period for one winding [s]', None), 'x'),
+        ('solver',  'initialization', None, 'cone_deg',             25.,        ('initial guess of reasonable period for one winding [s]', None), 'x'),
         ('solver',  'initialization', None, 'inclination_deg',      15.,        ('initial tether inclination angle [deg]', None),'x'),
         ('solver',  'initialization', None, 'min_rel_radius',       2.,         ('minimum allowed radius to span ratio allowed in initial guess [-]', None), 'x'),
         ('solver',  'initialization', None, 'kite_dcm',             'aero_validity',     ('initialize kite dcm so that aero validity constraints are satisfied, or based on circular geometry', ['aero_validity', 'circular']), 'x'),

--- a/awebox/opts/model_funcs.py
+++ b/awebox/opts/model_funcs.py
@@ -1174,22 +1174,16 @@ def estimate_energy(options, architecture):
 def estimate_time_period(options, architecture):
 
     windings = float(options['user_options']['trajectory']['lift_mode']['windings'])
-    winding_period = float(options['solver']['initialization']['winding_period'])
-
-    estimate_1 = windings * winding_period
+    cone_angle = float(options['solver']['initialization']['cone_deg'])*np.pi/180.0
+    ground_speed = float(options['solver']['initialization']['groundspeed'])
 
     number_of_kites = architecture.number_of_kites
     if number_of_kites == 1:
-        cone_angle = options['solver']['initialization']['max_cone_angle_single'] * np.pi / 180.
         length = options['solver']['initialization']['l_t']
     else:
-        cone_angle = options['solver']['initialization']['max_cone_angle_multi'] * np.pi / 180.
         length = options['solver']['initialization']['theta']['l_s']
     radius = length * np.sin(cone_angle)
-    acc_max = options['model']['model_bounds']['acceleration']['acc_max'] * options['model']['scaling']['other']['g']
 
-    estimate_2 = (2. * np.pi * windings) / np.sqrt( acc_max / radius)
-
-    time_period = (estimate_1 + estimate_2) / 2.
+    time_period = (2. * np.pi * windings * radius) / ground_speed
 
     return time_period

--- a/examples/ampyx_ap2_settings.py
+++ b/examples/ampyx_ap2_settings.py
@@ -64,7 +64,7 @@ def set_ampyx_ap2_settings(options):
     # initialization
     options['solver.initialization.groundspeed'] = 19.
     options['solver.initialization.inclination_deg'] = 45.
-    options['solver.initialization.l_t'] = 400.0
-    options['solver.initialization.winding_period'] = 40.0
+    options['solver.initialization.cone_deg'] = 18.
+    options['solver.initialization.l_t'] = 400.
 
     return options


### PR DESCRIPTION
It is easier to create a close-to-feasible initial guess by defining a cone angle rather than doing it implicitly via the winding period.