### PR TITLE
Output structure rework

### DIFF
--- a/awebox/ocp/nlp.py
+++ b/awebox/ocp/nlp.py
@@ -88,7 +88,9 @@ class NLP(object):
         Integral_outputs_fun,
         time_grids,
         Collocation,
-        Multiple_shooting] = discretization.discretize(nlp_options,model,formulation)
+        Multiple_shooting,
+        global_outputs,
+        global_outputs_fun] = discretization.discretize(nlp_options,model,formulation)
         self.__timings['discretization'] = time.time()-timer
 
         ocp_cstr_list.scale(nlp_options['constraint_scale'])
@@ -108,6 +110,8 @@ class NLP(object):
         self.__time_grids = time_grids
         self.__Collocation = Collocation
         self.__Multiple_shooting = Multiple_shooting
+        self.__global_outputs = global_outputs
+        self.__global_outputs_fun = global_outputs_fun
 
         self.__g = ocp_cstr_struct(ocp_cstr_list.get_expression_list('all'))
         self.__g_fun = ocp_cstr_list.get_function(nlp_options, V, P, 'all')
@@ -127,7 +131,7 @@ class NLP(object):
     def __generate_objective(self, nlp_options, model):
 
         timer = time.time()
-        [component_cost_function, component_cost_structure, f_fun] = objective.get_cost_function_and_structure(nlp_options, self.__V, self.__P, model.variables, model.parameters, self.__Xdot(self.__Xdot_fun(self.__V)), self.__Outputs(self.__Outputs_fun(self.__V, self.__P)), model, self.__Integral_outputs(self.__Integral_outputs_fun(self.__V, self.__P)))
+        [component_cost_function, component_cost_structure, f_fun] = objective.get_cost_function_and_structure(nlp_options, self.__V, self.__P, model.variables, model.parameters, self.__Xdot(self.__Xdot_fun(self.__V)), self.__Outputs_fun(self.__V, self.__P), model, self.__Integral_outputs(self.__Integral_outputs_fun(self.__V, self.__P)))
 
         self.__timings['objective'] = time.time()-timer
 
@@ -316,6 +320,22 @@ class NLP(object):
     @Outputs.setter
     def Outputs(self, value):
         awelogger.logger.warning('Cannot set Outputs object.')
+
+    @property
+    def global_outputs(self):
+        return self.__global_outputs
+
+    @global_outputs.setter
+    def global_outputs(self, value):
+        awelogger.logger.warning('Cannot set global_outputs object.')
+
+    @property
+    def global_outputs_fun(self):
+        return self.__global_outputs_fun
+
+    @global_outputs_fun.setter
+    def global_outputs_fun(self, value):
+        awelogger.logger.warning('Cannot set global_outputs_fun object.')
 
     @property
     def timings(self):

--- a/awebox/ocp/objective.py
+++ b/awebox/ocp/objective.py
@@ -397,13 +397,17 @@ def find_homotopy_cost(component_costs):
     return homotopy_cost
 
 def find_beta_cost(nlp_options, model, Outputs, P):
-
+    
     int_weights = find_int_weights(nlp_options)
+    d = nlp_options['collocation']['d']
     beta_cost = 0.0
     for kite in model.architecture.kite_nodes:
+
+        idx = struct_op.find_output_idx(model.outputs, 'aerodynamics', 'beta{}'.format(kite))
+
         for k in range(nlp_options['n_k']):
-            for j in range(nlp_options['collocation']['d']):
-                beta_cost += int_weights[j]*Outputs['coll_outputs', k, j, 'aerodynamics', 'beta{}'.format(kite)]**2
+            for j in range(d):
+                beta_cost += int_weights[j]*Outputs[idx, k*(d+1) + j + 1]**2
 
     beta_cost = P['cost', 'beta']*beta_cost / nlp_options['cost']['normalization']['beta']
 

--- a/awebox/opti/diagnostics.py
+++ b/awebox/opti/diagnostics.py
@@ -102,7 +102,7 @@ def compute_power_indicators(power_and_performance, plot_dict):
     else:
         e_final = plot_dict['x']['e'][0][-1]
 
-    time_period = plot_dict['output_vals'][1]['final', 'time_period', 'val']
+    time_period = plot_dict['global_outputs']['time_period'].full()[0][0]
     avg_power = e_final / time_period
     surface_area = float(len(plot_dict['architecture'].kite_nodes)) * s_ref
     power_per_surface_area = avg_power / surface_area

--- a/awebox/opti/optimization.py
+++ b/awebox/opti/optimization.py
@@ -631,14 +631,17 @@ class Optimization(object):
 
         # general outputs
         [nlp_outputs, nlp_output_fun] = nlp.output_components
-        outputs_init = nlp_outputs(nlp_output_fun(V_initial, self.__p_fix_num))
-        outputs_opt = nlp_outputs(nlp_output_fun(V_final, self.__p_fix_num))
-        outputs_ref = nlp_outputs(nlp_output_fun(self.__V_ref, self.__p_fix_num))
+        outputs_init = nlp_output_fun(V_initial, self.__p_fix_num)
+        outputs_opt = nlp_output_fun(V_final, self.__p_fix_num)
+        outputs_ref = nlp_output_fun(self.__V_ref, self.__p_fix_num)
 
         # integral outputs
         [nlp_integral_outputs, nlp_integral_outputs_fun] = nlp.integral_output_components
         integral_outputs_init = nlp_integral_outputs(nlp_integral_outputs_fun(V_initial, self.__p_fix_num))
         integral_outputs_opt = nlp_integral_outputs(nlp_integral_outputs_fun(V_final, self.__p_fix_num))
+
+        # global outputs
+        global_outputs_opt = nlp.global_outputs(nlp.global_outputs_fun(V_final, self.__p_fix_num))
 
         # time grids
         time_grids = {'ref':{}}
@@ -650,6 +653,7 @@ class Optimization(object):
         self.__outputs_opt = outputs_opt
         self.__outputs_init = outputs_init
         self.__outputs_ref = outputs_ref
+        self.__global_outputs_opt = global_outputs_opt
         self.__integral_outputs_init = integral_outputs_init
         self.__integral_outputs_opt = integral_outputs_opt
         self.__integral_outputs_fun = nlp_integral_outputs_fun
@@ -799,6 +803,10 @@ class Optimization(object):
     @property
     def output_vals(self):
         return [self.__outputs_init, self.__outputs_opt, self.__outputs_ref]
+
+    @property
+    def global_outputs_opt(self):
+        return self.__global_outputs_opt
 
     @property
     def integral_output_vals(self):

--- a/awebox/quality.py
+++ b/awebox/quality.py
@@ -54,7 +54,6 @@ class Quality(object):
 
         # run tests
         results = quality_funcs.test_invariants(trial, test_param_dict, results)
-        results = quality_funcs.test_outputs(trial, test_param_dict, results)
         results = quality_funcs.test_variables(trial, test_param_dict, results)
         results = quality_funcs.test_numerics(trial, test_param_dict, results)
         results = quality_funcs.test_power_balance(trial, test_param_dict, results)

--- a/awebox/tools/struct_operations.py
+++ b/awebox/tools/struct_operations.py
@@ -885,6 +885,16 @@ def generate_variable_struct(variable_list):
 
     return variable_struct, structs
 
+def find_output_idx(outputs, output_type, output_name, output_dim = 0):
+
+    kk = 0
+    can_index = outputs.getCanonicalIndex(kk)
+    while not (can_index[0] == output_type and can_index[1] == output_name and can_index[2] == output_dim):
+        kk += 1
+        can_index = outputs.getCanonicalIndex(kk)
+
+    return kk
+
 def get_variable_from_model_or_reconstruction(variables, var_type, name):
 
     if var_type in variables.keys():

--- a/awebox/trial.py
+++ b/awebox/trial.py
@@ -115,7 +115,7 @@ class Trial(object):
 
     def optimize(self, options_seed = [], final_homotopy_step = 'final',
                  warmstart_file = None, vortex_linearization_file = None, debug_flags = [],
-                 debug_locations = [], save_flag = False, intermediate_solve = False):
+                 debug_locations = [], save_flag = False, intermediate_solve = False, recalibrate_viz = True):
 
         if not options_seed:
             options = self.__options
@@ -160,11 +160,12 @@ class Trial(object):
 
             awelogger.logger.info('WARNING: Optimization of Trial (%s) failed.', self.__name)
 
-        cost_fun = self.nlp.cost_components[0]
-        cost = struct_op.evaluate_cost_dict(cost_fun, self.optimization.V_opt, self.optimization.p_fix_num)
-        self.visualization.recalibrate(self.optimization.V_opt,self.visualization.plot_dict, self.optimization.output_vals,
-                                        self.optimization.integral_outputs_final, self.options, self.optimization.time_grids,
-                                        cost, self.name, self.__optimization.V_ref)
+        if (not intermediate_solve and recalibrate_viz):
+            cost_fun = self.nlp.cost_components[0]
+            cost = struct_op.evaluate_cost_dict(cost_fun, self.optimization.V_opt, self.optimization.p_fix_num)
+            self.visualization.recalibrate(self.optimization.V_opt,self.visualization.plot_dict, self.optimization.output_vals,
+                                            self.optimization.integral_outputs_final, self.options, self.optimization.time_grids,
+                                            cost, self.name, self.__optimization.V_ref, self.__optimization.global_outputs_opt)
 
         # perform quality check
         self.__quality.check_quality(self)
@@ -180,6 +181,7 @@ class Trial(object):
 
         if V_plot is None:
             V_plot = self.__solution_dict['V_opt']
+            recalibrate = False
         if parametric_options is None:
             parametric_options = self.__options
         if output_vals == None:
@@ -191,7 +193,7 @@ class Trial(object):
         V_ref = self.__solution_dict['V_ref']
         trial_name = self.__solution_dict['name']
 
-        self.__visualization.plot(V_plot, parametric_options, output_vals, integral_outputs_final, flags, time_grids, cost, trial_name, sweep_toggle, V_ref, 'plot',fig_num)
+        self.__visualization.plot(V_plot, parametric_options, output_vals, integral_outputs_final, flags, time_grids, cost, trial_name, sweep_toggle, V_ref, self.__optimization.global_outputs_opt, 'plot',fig_num, recalibrate = recalibrate)
 
         return None
 

--- a/awebox/viz/tools.py
+++ b/awebox/viz/tools.py
@@ -264,7 +264,13 @@ def plot_output_block(plot_table_r, plot_table_c, params, output, plt, fig, idx,
 
     plt.subplot(plot_table_r, plot_table_c, idx)
     for n in kite_nodes:
-        output_values, tgrid, ndim = merge_output_values(output, output_type, output_name+str(n), dim, reload_dict, cosmetics)
+
+        kk = 0
+        can_index = reload_dict['outputs_struct'].getCanonicalIndex(kk)
+        while not (can_index[0] == output_type and can_index[1] == output_name):
+            kk += 1
+            can_index = reload_dict['outputs_struct'].getCanonicalIndex(kk)
+        output_values, tgrid, ndim = merge_output_values(output, kk, reload_dict, cosmetics)
 
         idx = kite_nodes.index(n)
         plt.plot(tgrid, output_values, color=cosmetics['diagnostics']['colors'][idx])
@@ -281,7 +287,7 @@ def plot_output_block(plot_table_r, plot_table_c, params, output, plt, fig, idx,
     else:
         plt.title(output_name)
 
-def merge_output_values(output_vals, output_type, output_name, dim, plot_dict, cosmetics, ref = False):
+def merge_output_values(output_vals, kk, plot_dict, cosmetics, ref = False):
 
     # read in inputs
     discretization = plot_dict['discretization']
@@ -315,36 +321,19 @@ def merge_output_values(output_vals, output_type, output_name, dim, plot_dict, c
 
     elif discretization == 'direct_collocation':
         if scheme != 'radau':
-            output_values = []
-            # merge interval and node values
-            for k in range(plot_dict['n_k']):
-                # add interval values
-                output_values = cas.vertcat(output_values, output_vals['outputs',k, output_type, output_name,dim])
-                if cosmetics['plot_coll']:
-                    # add node values
-                    output_values = cas.vertcat(output_values, cas.vertcat(*output_vals['coll_outputs',k, :, output_type, output_name,dim]))
-            output_values = np.array(output_values)
-            if cosmetics['plot_coll']:
-                tgrid = tgrid_u_coll
-            else:
-                tgrid = tgrid_u
-            ndim = output_vals['outputs',0,output_type,output_name].shape[0]
-
+            output_values = output_vals[kk,:]
+            tgrid = tgrid_u_coll
         else:
-            if cosmetics['plot_coll']:
-                # add only node values for radau case
-                output_values = np.array(struct_op.coll_slice_to_vec(output_vals['coll_outputs',:,:,output_type,output_name,dim]))
-                tgrid = tgrid_coll
-                ndim = output_vals['coll_outputs',0,0,output_type,output_name].shape[0]
-            else:
-                output_values = []
-                tgrid = []
-                ndim = 1
-
+            output_values = []
+            for k in range(plot_dict['n_k']):
+                output_values.append(output_vals[kk, k*(plot_dict['d']+1) + 1: k*(plot_dict['d']+1) + plot_dict['d']+1])
+            output_values = cas.horzcat(*output_values)
+            tgrid = tgrid_coll
+        ndim = 1
 
     # make list of time grid and values
     tgrid = list(chain.from_iterable(tgrid.full().tolist()))
-    output_values = list(chain.from_iterable(output_values))
+    output_values = output_values.full().squeeze()
 
     return output_values, tgrid, ndim
 
@@ -751,6 +740,7 @@ def calibrate_visualization(model, nlp, name, options):
     # model information
     plot_dict['integral_variables'] = list(model.integral_outputs.keys())
     plot_dict['outputs_dict'] = struct_op.strip_of_contents(model.outputs_dict)
+    plot_dict['outputs_struct'] = model.outputs
     plot_dict['architecture'] = model.architecture
     plot_dict['variables'] = struct_op.strip_of_contents(model.variables)
     plot_dict['parameters'] = struct_op.strip_of_contents(model.parameters)
@@ -764,7 +754,7 @@ def calibrate_visualization(model, nlp, name, options):
 
     return plot_dict
 
-def recalibrate_visualization(V_plot, plot_dict, output_vals, integral_outputs_final, options, time_grids, cost, name, V_ref, iterations=None, return_status_numeric=None, timings=None, N=None, ):
+def recalibrate_visualization(V_plot, plot_dict, output_vals, integral_outputs_final, options, time_grids, cost, name, V_ref, global_outputs, iterations=None, return_status_numeric=None, timings=None, N=None, ): 
     """
     Recalibrate plot dict with all calibration operation that need to be perfomed once for every plot.
     :param plot_dict: plot dictionary before recalibration
@@ -789,7 +779,7 @@ def recalibrate_visualization(V_plot, plot_dict, output_vals, integral_outputs_f
     # get new outputs
     plot_dict['output_vals'] = output_vals
     plot_dict['integral_outputs_final'] = integral_outputs_final
-
+    plot_dict['global_outputs'] = global_outputs
     # get new time grids
     plot_dict['time_grids'] = time_grids
     if plot_dict['discretization'] == 'direct_collocation':
@@ -918,16 +908,21 @@ def interpolate_data(plot_dict, cosmetics):
             plot_dict['u'][name] += [values_ip]
 
     # output values
-    for output_type in list(outputs_dict.keys()):
-        plot_dict['outputs'][output_type] = {}
-        for name in list(outputs_dict[output_type].keys()):
+    for kk in range(output_vals.shape[0]):
+        can_index = plot_dict['outputs_struct'].getCanonicalIndex(kk)
+        output_type = can_index[0]
+        name = can_index[1]
+        j = can_index[2]
+        if output_type not in list(plot_dict['outputs'].keys()):
+            plot_dict['outputs'][output_type] = {}
+        if name not in list(plot_dict['outputs'][output_type].keys()):
             plot_dict['outputs'][output_type][name] = []
-            for j in range(outputs_dict[output_type][name].shape[0]):
-                # merge values
-                values, time_grid, ndim = merge_output_values(output_vals, output_type, name, j, plot_dict, cosmetics)
-                # inteprolate
-                values_ip = spline_interpolation(time_grid, values, plot_dict['time_grids']['ip'], n_points, name)
-                plot_dict['outputs'][output_type][name] += [values_ip]
+
+        # merge values
+        values, time_grid, ndim = merge_output_values(output_vals, kk, plot_dict, cosmetics)
+        # inteprolate
+        values_ip = spline_interpolation(time_grid, values, plot_dict['time_grids']['ip'], n_points, name)
+        plot_dict['outputs'][output_type][name] += [values_ip]
 
     # integral outptus
     if plot_dict['discretization'] == 'direct_collocation':
@@ -1010,16 +1005,21 @@ def interpolate_ref_data(plot_dict, cosmetics):
             plot_dict['ref']['u'][name] += [values_ip]
 
     # output values
-    for output_type in list(outputs_dict.keys()):
-        plot_dict['ref']['outputs'][output_type] = {}
-        for name in list(outputs_dict[output_type].keys()):
+    for kk in range(output_vals.shape[0]):
+        can_index = plot_dict['outputs_struct'].getCanonicalIndex(kk)
+        output_type = can_index[0]
+        name = can_index[1]
+        j = can_index[2]
+        if output_type not in list(plot_dict['outputs'].keys()):
+            plot_dict['ref']['outputs'][output_type] = {}
+        if name not in list(plot_dict['outputs'][output_type].keys()):
             plot_dict['ref']['outputs'][output_type][name] = []
-            for j in range(outputs_dict[output_type][name].shape[0]):
-                # merge values
-                values, time_grid, ndim = merge_output_values(output_vals, output_type, name, j, plot_dict, cosmetics, ref = True)
-                # interpolate
-                values_ip = spline_interpolation(time_grid, values, plot_dict['time_grids']['ref']['ip'], n_points, name)
-                plot_dict['ref']['outputs'][output_type][name] += [values_ip]
+
+        # merge values
+        values, time_grid, ndim = merge_output_values(output_vals, kk, plot_dict, cosmetics)
+        # inteprolate
+        values_ip = spline_interpolation(time_grid, values, plot_dict['time_grids']['ip'], n_points, name)
+        plot_dict['ref']['outputs'][output_type][name] += [values_ip]
 
     return plot_dict
 

--- a/awebox/viz/tools.py
+++ b/awebox/viz/tools.py
@@ -312,14 +312,7 @@ def merge_output_values(output_vals, kk, plot_dict, cosmetics, ref = False):
     else:
         tgrid_u = plot_dict['time_grids']['ref']['u']
 
-    if discretization == 'multiple_shooting':
-        # take interval values
-        output_values = np.array(cas.vertcat(*output_vals['outputs',:,output_type,output_name,dim]).full())
-        tgrid = tgrid_u
-
-        ndim = output_vals['outputs',0,output_type,output_name].shape[0]
-
-    elif discretization == 'direct_collocation':
+    if discretization == 'direct_collocation':
         if scheme != 'radau':
             output_values = output_vals[kk,:]
             tgrid = tgrid_u_coll

--- a/awebox/viz/visualization.py
+++ b/awebox/viz/visualization.py
@@ -68,13 +68,13 @@ class Visualization(object):
 
         return None
 
-    def recalibrate(self, V_plot, plot_dict, output_vals, integral_outputs_final, parametric_options, time_grids, cost, name, V_ref):
+    def recalibrate(self, V_plot, plot_dict, output_vals, integral_outputs_final, parametric_options, time_grids, cost, name, V_ref, global_outputs):
 
-        self.__plot_dict = tools.recalibrate_visualization(V_plot, plot_dict, output_vals, integral_outputs_final, parametric_options, time_grids, cost, name, V_ref)
+        self.__plot_dict = tools.recalibrate_visualization(V_plot, plot_dict, output_vals, integral_outputs_final, parametric_options, time_grids, cost, name, V_ref, global_outputs)
 
         return None
 
-    def plot(self, V_plot, parametric_options, output_vals, integral_outputs_final, flags, time_grids, cost, name, sweep_toggle, V_ref, fig_name='plot', fig_num = None, recalibrate = True):
+    def plot(self, V_plot, parametric_options, output_vals, integral_outputs_final, flags, time_grids, cost, name, sweep_toggle, V_ref, global_outputs, fig_name='plot', fig_num = None, recalibrate = True):
         """
         Generate plots with given parametric and visualization options
         :param V_plot: plot data (scaled)
@@ -85,7 +85,7 @@ class Visualization(object):
 
         # recalibrate plot_dict
         if recalibrate:
-            self.recalibrate(V_plot, self.__plot_dict, output_vals, integral_outputs_final, parametric_options, time_grids, cost, name, V_ref)
+            self.recalibrate(V_plot, self.__plot_dict, output_vals, integral_outputs_final, parametric_options, time_grids, cost, name, V_ref, global_outputs)
 
         if type(flags) is not list:
             flags = [flags]


### PR DESCRIPTION
- remove `Outputs_struct` (except for vortex models), since it was a very inefficient sorting mechanism
- remove duplicate calls of visualization recalibration routine