### PR TITLE
Side-slip angle sign bugfix

### DIFF
--- a/awebox/mdl/aero/kite_dir/stability_derivatives.py
+++ b/awebox/mdl/aero/kite_dir/stability_derivatives.py
@@ -144,6 +144,9 @@ def collect_inputs(alpha, beta, airspeed, omega, delta, parameters, named_frame)
 
     p, q, r = get_p_q_r(airspeed, omega, parameters, named_frame)
 
+    if named_frame == 'control':
+        beta = - beta # correct sign of beta to be used in control frame
+
     inputs = {}
     inputs['0'] = cas.DM(1.)
     inputs['alpha'] = alpha


### PR DESCRIPTION
If the stability derivatives are defined in the `"control"` frame, the sign should be switched.

Has no real effect on previously computed optimal solutions.