### PR TITLE
Add switch to enable inequalities at collocation nodes

### DIFF
--- a/awebox/ocp/var_bounds.py
+++ b/awebox/ocp/var_bounds.py
@@ -52,6 +52,11 @@ def get_scaled_variable_bounds(nlp_options, V, model):
 
     periodic = perf_op.determine_if_periodic(nlp_options)
 
+    u_poly = (nlp_options['collocation']['u_param'] == 'poly')
+    u_zoh_ineq_shoot = (nlp_options['collocation']['u_param'] == 'zoh') and (nlp_options['collocation']['ineq_constraints'] == 'shooting_nodes')
+    u_zoh_ineq_coll = (nlp_options['collocation']['u_param'] == 'zoh') and (nlp_options['collocation']['ineq_constraints'] == 'collocation_nodes')
+    inequalities_at_collocation_nodes = u_poly or u_zoh_ineq_coll
+
     # fill in bounds
     for canonical in distinct_variables:
 
@@ -60,11 +65,11 @@ def get_scaled_variable_bounds(nlp_options, V, model):
 
         if (var_type == 'x'):
 
-            if nlp_options['collocation']['u_param'] == 'poly' and var_is_coll_var:
+            if var_is_coll_var and u_poly:
                 vars_lb['coll_var', kdx, ddx, var_type, name] = model.variable_bounds[var_type][name]['lb']
                 vars_ub['coll_var', kdx, ddx, var_type, name] = model.variable_bounds[var_type][name]['ub']
             
-            elif nlp_options['collocation']['u_param'] == 'zoh' and use_depending_on_periodicity  and (not var_is_coll_var):
+            elif use_depending_on_periodicity  and (not var_is_coll_var) and not u_poly:
                 vars_lb[var_type, kdx, name] = model.variable_bounds[var_type][name]['lb']
                 vars_ub[var_type, kdx, name] = model.variable_bounds[var_type][name]['ub']
 
@@ -77,7 +82,7 @@ def get_scaled_variable_bounds(nlp_options, V, model):
                 vars_lb[var_type, kdx, name] = model.variable_bounds[var_type][name]['lb']
                 vars_ub[var_type, kdx, name] = model.variable_bounds[var_type][name]['ub']
 
-            elif nlp_options['collocation']['u_param'] == 'poly' and var_is_coll_var:
+            elif var_is_coll_var and inequalities_at_collocation_nodes:
                 vars_lb['coll_var', kdx, ddx, var_type, name] = model.variable_bounds[var_type][name]['lb']
                 vars_ub['coll_var', kdx, ddx, var_type, name] = model.variable_bounds[var_type][name]['ub']
 

--- a/awebox/opts/default.py
+++ b/awebox/opts/default.py
@@ -279,6 +279,7 @@ def set_default_options(default_user_options, help_options):
         ('nlp',  'collocation',      None, 'd',                    4,                      ('degree of lagrange polynomials inside collocation interval [int]', None),'t'),
         ('nlp',  'collocation',      None, 'scheme',               'radau',                ('collocation scheme', ['radau','legendre']),'x'),
         ('nlp',  'collocation',      None, 'u_param',              'poly',                  ('control parameterization in collocation interval', ['poly','zoh']),'x'),
+        ('nlp',  'collocation',      None, 'ineq_constraints',     'shooting_nodes',       ('impose path constraints at collocation nodes in zoh case', ['shooting_nodes', 'collocation_nodes']),'x'),
         ('nlp',  'collocation',      None, 'name_constraints',     False,                  ('names nlp collocation constraints according to the extended model constraint. slow, but useful when debugging licq problems with the health check', [True, False]), 't'),
         ('nlp',  None,               None, 'phase_fix_reelout',    0.7,                    ('time fraction of reel-out phase', None),'x'),
         ('nlp',  None,               None, 'pumping_range',        [None, None],           ('set predefined pumping range (only in comb. w. phase-fix)', None),'x'),


### PR DESCRIPTION
Add switch to enable inequalities at collocation nodes even for zero-order hold:

```
options['nlp.collocation.ineq_constraints'] = 'collocation_nodes'
```

The default option remains:

```
options['nlp.collocation.ineq_constraints'] = 'shooting_nodes'
```

What happens if the options `collocation_nodes` is chosen with `u_param = 'zoh'`?
- `path_constraints` are imposed on coll_nodes, not on shooting nodes
- variable bounds on `z` are imposed on coll nodes and shooting nodes
- variable bounds on `x` and `u` only on shooting nodes, to avoid obvious LICQ violations.

To do:
- make variable bound on `z` at shooting node dependent on control var / collocation scheme.
- add check on the dependency of the path_constraints on the controls to avoid LICQ.
- add check that compares the control DOF with number of collocation nodes, to avoid overconstrained problems.

### Test on example `ampyx_ap2_trajectory.py`:
`shooting_nodes`: 
Average power output: 4.6856  kW
Time period: 35.6575  s

![inequalities_shooting_nodes](https://github.com/awebox/awebox/assets/28870597/45c432c5-61a5-45ee-b3bf-c2f0a4361533)
![inequalities_shooting_nodes2](https://github.com/awebox/awebox/assets/28870597/a077f579-573a-420c-b347-41ac937777be)


`collocation_nodes`:
Average power output: 4.59435  kW
Time period: 34.7217   s

![inequalities_collocation_nodes](https://github.com/awebox/awebox/assets/28870597/e0b5657f-fc01-4804-975a-3dd6f30dc736)
![inequalities_coll_nodes2](https://github.com/awebox/awebox/assets/28870597/62d9da1d-64e9-4676-9ee8-be6a91e0b2ba)

