### PR TITLE
Compute coll_vars and coll_params only once

### DIFF
--- a/awebox/ocp/collocation.py
+++ b/awebox/ocp/collocation.py
@@ -62,6 +62,10 @@ class Collocation(object):
         self.__poly_coeffs()
         self.__quadrature_weights()
 
+        # model variables and parameters
+        self.__coll_vars = None
+        self.__coll_params = None
+
         return None
 
     def __poly_coeffs(self):
@@ -235,6 +239,21 @@ class Collocation(object):
 
         return Xdot
 
+    def get_coll_vars_and_params(self, nlp_options, V, P, Xdot, model, recompute = False):
+
+        if self.__coll_vars is None:
+            self.__coll_vars = struct_op.get_coll_vars(nlp_options, V, P, Xdot, model)
+            self.__coll_params = struct_op.get_coll_params(nlp_options, V, P, model)
+            coll_vars = self.__coll_vars
+            coll_params = self.__coll_params
+        elif recompute:
+            coll_vars = struct_op.get_coll_vars(nlp_options, V, P, Xdot, model)
+            coll_params = struct_op.get_coll_params(nlp_options, V, P, model)
+        else:
+            coll_vars = self.__coll_vars
+            coll_params = self.__coll_params
+
+        return coll_vars, coll_params
 
     def __calculate_collocation_deriv(self, V, k, j):
         """ Compute derivative of polynomial at specific node
@@ -356,8 +375,7 @@ class Collocation(object):
             shooting_params = struct_op.get_shooting_params(options, V, P, model)
 
         # construct list of all collocation node variables and parameters
-        coll_vars = struct_op.get_coll_vars(options, V, P, Xdot, model)
-        coll_params = struct_op.get_coll_params(options, V, P, model)
+        coll_vars, coll_params = self.get_coll_vars_and_params(options, V, P, Xdot, model)
 
         # initialize function evaluations
         coll_outputs = []

--- a/awebox/ocp/constraints.py
+++ b/awebox/ocp/constraints.py
@@ -232,8 +232,7 @@ def expand_with_collocation(nlp_options, P, V, Xdot, model, Collocation):
 
     # collect collocation variables
     coll_nodes = n_k*d
-    coll_vars = struct_op.get_coll_vars(nlp_options, V, P, Xdot, model)
-    coll_params = struct_op.get_coll_params(nlp_options, V, P, model)
+    coll_vars, coll_params = Collocation.get_coll_vars_and_params(nlp_options, V, P, Xdot, model)
 
     # create maps of relevant functions
     mdl_ineq_fun = model_constraints_list.get_function(nlp_options, model_variables, model_parameters, 'ineq')

--- a/awebox/ocp/nlp.py
+++ b/awebox/ocp/nlp.py
@@ -139,7 +139,7 @@ class NLP(object):
             Outputs = self.__Outputs
         else:
             Outputs = self.__Outputs_fun(self.__V, self.__P)
-        [component_cost_function, component_cost_structure, f_fun] = objective.get_cost_function_and_structure(nlp_options, self.__V, self.__P, model.variables, model.parameters, self.__Xdot(self.__Xdot_fun(self.__V)), Outputs, model, self.__Integral_outputs(self.__Integral_outputs_fun(self.__V, self.__P)))
+        [component_cost_function, component_cost_structure, f_fun] = objective.get_cost_function_and_structure(nlp_options, self.__V, self.__P, model.variables, model.parameters, self.__Collocation, self.__Xdot(self.__Xdot_fun(self.__V)), Outputs, model, self.__Integral_outputs(self.__Integral_outputs_fun(self.__V, self.__P)))
 
         self.__timings['objective'] = time.time()-timer
 
@@ -151,12 +151,12 @@ class NLP(object):
 
     def get_nlp(self):
 
-        # construct constraints
-        g = self.__g_fun(self.__V, self.__P)
-        f = self.__f_fun(self.__V, self.__P)
+        # # construct constraints
+        # g = self.__g_fun(self.__V, self.__P)
+        # f = self.__f_fun(self.__V, self.__P)
 
         # fill in nlp dict
-        nlp = {'x': self.__V, 'p': self.__P, 'f': f, 'g': g}
+        nlp = {'x': self.__V, 'p': self.__P, 'f': self.__f_fun, 'g': self.__g_fun}
 
         return nlp
 

--- a/awebox/ocp/nlp.py
+++ b/awebox/ocp/nlp.py
@@ -151,12 +151,12 @@ class NLP(object):
 
     def get_nlp(self):
 
-        # # construct constraints
-        # g = self.__g_fun(self.__V, self.__P)
-        # f = self.__f_fun(self.__V, self.__P)
+        # construct constraints
+        g = self.__g_fun(self.__V, self.__P)
+        f = self.__f_fun(self.__V, self.__P)
 
         # fill in nlp dict
-        nlp = {'x': self.__V, 'p': self.__P, 'f': self.__f_fun, 'g': self.__g_fun}
+        nlp = {'x': self.__V, 'p': self.__P, 'f': f, 'g': g}
 
         return nlp
 

--- a/awebox/ocp/objective.py
+++ b/awebox/ocp/objective.py
@@ -170,7 +170,7 @@ def get_regularization_weights(variables, P, nlp_options):
     return weights
 
 
-def get_coll_parallel_info(nlp_options, V, P, Xdot, model):
+def get_coll_parallel_info(nlp_options, V, P, Xdot, model, Collocation):
 
     n_k = nlp_options['n_k']
     d = nlp_options['collocation']['d']
@@ -183,8 +183,8 @@ def get_coll_parallel_info(nlp_options, V, P, Xdot, model):
         for ddx in range(d):
             coll_weights = cas.horzcat(coll_weights, int_weights[ddx] * p_weights)
 
-    coll_vars = struct_op.get_coll_vars(nlp_options, V, P, Xdot, model)
-    coll_refs = struct_op.get_coll_vars(nlp_options, V(P['p', 'ref']), P, Xdot(0.0), model)
+    coll_vars, _ = Collocation.get_coll_vars_and_params(nlp_options, V, P, Xdot, model)
+    coll_refs, _ = Collocation.get_coll_vars_and_params(nlp_options, V(P['p', 'ref']), P, Xdot(0.0), model, recompute = True)
 
     return coll_vars, coll_refs, coll_weights, N_coll
 
@@ -204,13 +204,13 @@ def get_ms_parallel_info(nlp_options, V, P, Xdot, model):
     return ms_vars, ms_refs, ms_weights, N_ms
 
 
-def find_general_regularisation(nlp_options, V, P, Xdot, model):
+def find_general_regularisation(nlp_options, V, P, Xdot, model, Collocation):
 
     variables = model.variables
 
     direct_collocation, multiple_shooting, _, _, _ = extract_discretization_info(nlp_options)
     if direct_collocation:
-        vars, refs, weights, N_steps = get_coll_parallel_info(nlp_options, V, P, Xdot, model)
+        vars, refs, weights, N_steps = get_coll_parallel_info(nlp_options, V, P, Xdot, model, Collocation)
     elif multiple_shooting:
         vars, refs, weights, N_steps = get_ms_parallel_info(nlp_options, V, P, Xdot, model)
     parallellization = nlp_options['parallelization']['type']
@@ -449,9 +449,9 @@ def find_objective(component_costs, V, V_ref, nlp_options):
 
 ##### use the component_cost_dictionary to only do the calculation work once
 
-def get_component_cost_dictionary(nlp_options, V, P, variables, parameters, xdot, Outputs, model, Integral_outputs):
+def get_component_cost_dictionary(nlp_options, V, P, variables, Collocation, xdot, Outputs, model, Integral_outputs):
 
-    component_costs = find_general_regularisation(nlp_options, V, P, xdot, model)
+    component_costs = find_general_regularisation(nlp_options, V, P, xdot, model, Collocation)
 
     component_costs = find_homotopy_parameter_costs(component_costs, V, P)
 
@@ -489,9 +489,9 @@ def get_component_cost_structure(component_costs):
 
     return component_cost_struct
 
-def get_cost_function_and_structure(nlp_options, V, P, variables, parameters, xdot, Outputs, model, Integral_outputs):
+def get_cost_function_and_structure(nlp_options, V, P, variables, parameters, Collocation, xdot, Outputs, model, Integral_outputs):
 
-    component_costs = get_component_cost_dictionary(nlp_options, V, P, variables, parameters, xdot, Outputs, model, Integral_outputs)
+    component_costs = get_component_cost_dictionary(nlp_options, V, P, variables, Collocation, xdot, Outputs, model, Integral_outputs)
 
     component_cost_function = get_component_cost_function(component_costs, V, P)
     component_cost_structure = get_component_cost_structure(component_costs)

--- a/test/units/test_objective.py
+++ b/test/units/test_objective.py
@@ -99,7 +99,7 @@ def run_generalized_regularization_mechanism_test(with_additional_exceptions=Fal
 
     include_shooting_nodes = we_expect_shooting_nodes_to_also_be_weighted(trial)
 
-    component_costs = objective.find_general_regularisation(nlp_options, V, P, Xdot, model)
+    component_costs = objective.find_general_regularisation(nlp_options, V, P, Xdot, model, trial.nlp.Collocation)
 
     var_to_find, var_type, usual_cost_type = get_relevant_variable_info()
     relevant_indices = get_the_indices_of_the_relevant_variable_instances(V, var_type, var_to_find, include_shooting_nodes=include_shooting_nodes)


### PR DESCRIPTION
Save `coll_vars` and `coll_params` lists in `Collocation` object to be re-used.

Save around 30 seconds building time in the `ampyx_ap2_trajectory` example.