### PR TITLE
Parallel construction

### DIFF
--- a/awebox/opti/preparation.py
+++ b/awebox/opti/preparation.py
@@ -28,7 +28,6 @@ python-3.5 / casadi-3.4.5
 - authors: rachel leuthold, thilo bronnenmeyer, alu-fr 2018
 '''
 
-
 from . initialization_dir import modular as initialization_modular, initialization
 
 from . import reference
@@ -303,7 +302,6 @@ def generate_hippo_strategy_solvers(awebox_callback, nlp, options):
         final_opts['ipopt.mu_init'] = options['mu_hippo']
         final_opts['ipopt.warm_start_init_point'] = 'yes'
 
-
     if options['callback']:
         initial_opts['iteration_callback'] = awebox_callback
         initial_opts['iteration_callback_step'] = options['callback_step']
@@ -314,16 +312,84 @@ def generate_hippo_strategy_solvers(awebox_callback, nlp, options):
         final_opts['iteration_callback'] = awebox_callback
         final_opts['iteration_callback_step'] = options['callback_step']
 
-    initial_solver = cas.nlpsol('solver', 'ipopt', nlp.get_nlp(), initial_opts)
-    middle_solver = cas.nlpsol('solver', 'ipopt', nlp.get_nlp(), middle_opts)
-    final_solver = cas.nlpsol('solver', 'ipopt', nlp.get_nlp(), final_opts)
+    bundled_nlp = {'V': nlp.V, 'P': nlp.P, 'f_fun': nlp.f_fun, 'g_fun': nlp.g_fun}
+    dict_of_bundled_nlp_and_options = {}
+    ordered_names = ['initial', 'middle', 'final']
+    for name in ordered_names:
+        dict_of_bundled_nlp_and_options[name] = copy.deepcopy(bundled_nlp)
+
+    dict_of_bundled_nlp_and_options['initial']['opts'] = initial_opts
+    dict_of_bundled_nlp_and_options['middle']['opts'] = middle_opts
+    dict_of_bundled_nlp_and_options['final']['opts'] = final_opts
 
     solvers = {}
-    solvers['initial'] = initial_solver
-    solvers['middle'] = middle_solver
-    solvers['final'] = final_solver
 
+    generation_method = options['generation_method']
+
+    if generation_method == 'serial':
+        for name in ordered_names:
+            solvers[name] = construct_single_solver_from_bundle(dict_of_bundled_nlp_and_options[name])
+        results = None
+
+    elif generation_method == 'multiprocessing_pool':
+        from multiprocessing import Pool, Lock
+        list_of_bundles = [dict_of_bundled_nlp_and_options[name] for name in ordered_names]
+        pool = Pool(processes=len(list_of_bundles))
+        results = pool.map(construct_single_solver_from_bundle, list_of_bundles)
+
+    elif generation_method == 'concurrent_futures':
+        from concurrent.futures import ThreadPoolExecutor
+        with ThreadPoolExecutor() as executor:
+            # Submit tasks for each argument
+            futures = [executor.submit(construct_single_solver_from_bundle, dict_of_bundled_nlp_and_options[name]) for name in ordered_names]
+
+            # Optionally: Collect results (if the function returns anything)
+            results = [future.result() for future in futures]
+
+    elif generation_method == 'pathos':
+        from pathos.multiprocessing import ProcessingPool as Pool
+        list_of_bundles = [dict_of_bundled_nlp_and_options[name] for name in ordered_names]
+        with Pool() as pool:
+            results = pool.map(construct_single_solver_from_bundle, list_of_bundles)
+
+    elif generation_method == 'joblib':
+        from joblib import Parallel, delayed
+        results = Parallel(n_jobs=len(ordered_names))(delayed(construct_single_solver_from_bundle)(dict_of_bundled_nlp_and_options[name]) for name in ordered_names)
+
+    elif generation_method == 'gevent':
+        import gevent
+        from gevent.pool import Pool
+
+        list_of_bundles = [dict_of_bundled_nlp_and_options[name] for name in ordered_names]
+        pool = Pool(len(list_of_bundles))
+        results = pool.map(construct_single_solver_from_bundle, list_of_bundles)
+
+    else:
+        message = 'unfamiliar solver generation method (' + generation_method + ')'
+        print_op.log_and_raise_error(message)
+
+
+    if (generation_method != 'serial') and (results is not None):
+        for idx in range(len(ordered_names)):
+            solvers[ordered_names[idx]] = results[idx]
     return solvers
+
+
+def construct_single_solver_from_bundle(bundled_nlp_and_options):
+
+    local_V = bundled_nlp_and_options['V']
+    local_P = bundled_nlp_and_options['P']
+    local_f_fun = bundled_nlp_and_options['f_fun']
+    local_g_fun = bundled_nlp_and_options['g_fun']
+
+    local_f = local_f_fun(local_V, local_P)
+    local_g = local_g_fun(local_V, local_P)
+
+    # fill in nlp dict
+    local_nlp = {'x': local_V, 'p': local_P, 'f': local_f, 'g': local_g}
+    local_opts = bundled_nlp_and_options['opts']
+    local_solver = cas.nlpsol('solver', 'ipopt', local_nlp, local_opts)
+    return local_solver
 
 
 def generate_nonhippo_strategy_solvers(awebox_callback, nlp, options):

--- a/awebox/opts/default.py
+++ b/awebox/opts/default.py
@@ -313,6 +313,7 @@ def set_default_options(default_user_options, help_options):
 
         ### solver options
         ('solver',  None,   None,   'generate_solvers',     True,       ('trial.optimization should generate the casadi solver', [True, False]), 'x'),
+        ('solver',  None,   None,   'generation_method',    'serial',   ('method of generating the solvers. multiprocessing_pool generates in roughly 70% the time of the serial generation, but requires roughly 2-3x as much memory. the time savings increases and memory cost decreases for larger problems.', ['serial', 'multiprocessing_pool', 'concurrent_futures', 'pathos', 'joblib', 'gevent']), 'x'),
         ('solver',  None,   None,   'nlp_solver',          'ipopt',     ('which NLP solver to use', ['ipopt', 'worhp']),'x'),
         ('solver',  None,   None,   'linear_solver',       'mumps',     ('which linear solver to use', ['mumps', 'ma57']),'x'),
         ('solver',  None,   None,   'hessian_approximation',False,      ('use a limited-memory hessian approximation instead of the exact Newton hessian', [True, False]),'x'),

--- a/test/reg/test_parallelization.py
+++ b/test/reg/test_parallelization.py
@@ -1,4 +1,7 @@
 import casadi as cd
+import awebox.opts.kite_data.ampyx_data as ampyx_data
+import awebox as awe
+import awebox.trial as awe_trial
 
 def test_parallelization():
     N = 300
@@ -9,5 +12,29 @@ def test_parallelization():
     F(x0=0, z0=0, p=0)
 
 
+def test_parallel_solver_generation():
+    trial_options = {}
+    trial_options['user_options.system_model.architecture'] = {1: 0}
+    trial_options['user_options.system_model.kite_dof'] = 3
+    trial_options['user_options.kite_standard'] = awe.ampyx_data.data_dict()
+    trial_options['user_options.trajectory.system_type'] = 'lift_mode'
+    trial_options['user_options.trajectory.lift_mode.windings'] = 1
+    trial_options['model.tether.aero_elements'] = 1
+    trial_options['user_options.induction_model'] = 'not_in_use'
+    trial_options['nlp.collocation.u_param'] = 'zoh'
+    trial_options['nlp.n_k'] = 5
+    trial_options['solver.max_iter'] = 2
+
+    for solver_generation_method in ['serial', 'multiprocessing_pool']:
+        trial_options['solver.generation_method'] = solver_generation_method
+
+        trial_name = solver_generation_method
+
+        # compute trajectory solution
+        trial = awe_trial.Trial(trial_options, trial_name)
+        trial.build()
+        trial.optimize(final_homotopy_step='initial')
+
 if __name__ == "__main__":
     test_parallelization()
+    test_parallel_solver_generation()

--- a/test/trials/test_trials.py
+++ b/test/trials/test_trials.py
@@ -257,6 +257,7 @@ def generate_options_dict():
     single_kite_options['nlp.collocation.u_param'] = 'zoh'
     single_kite_options['nlp.n_k'] = 20
     single_kite_options['quality.raise_exception'] = True
+    single_kite_options['solver.generation_method'] = 'multiprocessing_pool'
 
     single_kite_basic_health_options = make_basic_health_variant(single_kite_options)
 

--- a/test/trials/test_trials.py
+++ b/test/trials/test_trials.py
@@ -462,11 +462,11 @@ if __name__ == "__main__":
     test_dual_kite_6_dof_basic_health()
     test_dual_kite_6_dof()
 
-    # # test_small_dual_kite()
-    # # test_small_dual_kite_basic_health()
-    # # test_large_dual_kite()
-    # # test_large_dual_kite_basic_health()
-
+    # # # test_small_dual_kite()
+    # # # test_small_dual_kite_basic_health()
+    # # # test_large_dual_kite()
+    # # # test_large_dual_kite_basic_health()
+    #
     test_dual_kite_tracking()
     test_dual_kite_tracking_winch()
 


### PR DESCRIPTION
trying out different options for breaking the three hippo solver constructions into parallel. 
the main versions are 'serial' (as-is) and 'multiprocessing-pool', but i left in the other methods for the present because: 

- multiprocessing_pool and pathos are roughly equal in terms of memory and time useage, the others are 'worse' in some way or another
- some require specific packages to be installed, so if a user has one package already installed they can choose that one. 

@Jochem: if you think this is unnecessary feature creep (and you doubt that we'll be able to maintain it), then feel free to delete every option other than 'serial', 'multiprocessing_pool' and 'pathos'