### PR TITLE
added option file to set matplotlib backend in one place

### DIFF
--- a/awebox/mdl/aero/induction_dir/vortex_dir/alg_repr_dir/algebraic_representation.py
+++ b/awebox/mdl/aero/induction_dir/vortex_dir/alg_repr_dir/algebraic_representation.py
@@ -28,7 +28,8 @@ _python-3.5 / casadi-3.4.5
 - author: rachel leuthold, alu-fr 2019-21
 '''
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
 
 import casadi.tools as cas

--- a/awebox/mdl/aero/induction_dir/vortex_dir/alg_repr_dir/bound_wake.py
+++ b/awebox/mdl/aero/induction_dir/vortex_dir/alg_repr_dir/bound_wake.py
@@ -28,7 +28,8 @@ _python-3.5 / casadi-3.4.5
 - author: rachel leuthold, alu-fr 2022
 '''
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
 
 import casadi.tools as cas

--- a/awebox/mdl/aero/induction_dir/vortex_dir/alg_repr_dir/far_wake.py
+++ b/awebox/mdl/aero/induction_dir/vortex_dir/alg_repr_dir/far_wake.py
@@ -28,7 +28,8 @@ _python-3.5 / casadi-3.4.5
 - author: rachel leuthold, alu-fr 2022
 '''
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
 
 import copy

--- a/awebox/mdl/aero/induction_dir/vortex_dir/alg_repr_dir/near_wake.py
+++ b/awebox/mdl/aero/induction_dir/vortex_dir/alg_repr_dir/near_wake.py
@@ -28,7 +28,8 @@ _python-3.5 / casadi-3.4.5
 - author: rachel leuthold, alu-fr 2022
 '''
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
 
 import casadi.tools as cas

--- a/awebox/mdl/aero/induction_dir/vortex_dir/alg_repr_dir/structure.py
+++ b/awebox/mdl/aero/induction_dir/vortex_dir/alg_repr_dir/structure.py
@@ -28,7 +28,8 @@ _python-3.5 / casadi-3.4.5
 - author: rachel leuthold, alu-fr 2022
 '''
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
 
 import casadi.tools as cas

--- a/awebox/mdl/aero/induction_dir/vortex_dir/vortex_objects_dir/element.py
+++ b/awebox/mdl/aero/induction_dir/vortex_dir/vortex_objects_dir/element.py
@@ -28,7 +28,8 @@ _python-3.5 / casadi-3.4.5
 - authors: rachel leuthold 2021
 '''
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
 
 import copy
@@ -42,7 +43,7 @@ import awebox.tools.print_operations as print_op
 from awebox.logger.logger import Logger as awelogger
 
 import matplotlib
-matplotlib.use('TkAgg')
+matplotlib.use(DEFAULT_MPL_BACKEND)
 
 class Element():
     def __init__(self, info_dict, info_order=None):

--- a/awebox/mdl/aero/induction_dir/vortex_dir/vortex_objects_dir/element_list.py
+++ b/awebox/mdl/aero/induction_dir/vortex_dir/vortex_objects_dir/element_list.py
@@ -43,8 +43,10 @@ import awebox.tools.print_operations as print_op
 from awebox.logger.logger import Logger as awelogger
 
 import matplotlib
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
-matplotlib.use('TkAgg')
+
 
 class ElementList():
 

--- a/awebox/mdl/aero/induction_dir/vortex_dir/vortex_objects_dir/finite_filament.py
+++ b/awebox/mdl/aero/induction_dir/vortex_dir/vortex_objects_dir/finite_filament.py
@@ -42,9 +42,11 @@ import awebox.tools.print_operations as print_op
 from awebox.logger.logger import Logger as awelogger
 
 import matplotlib
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import awebox.mdl.aero.induction_dir.vortex_dir.tools as vortex_tools
 
-matplotlib.use('TkAgg')
+
 
 
 class FiniteFilament(obj_element.Element):

--- a/awebox/mdl/aero/induction_dir/vortex_dir/vortex_objects_dir/semi_infinite_filament.py
+++ b/awebox/mdl/aero/induction_dir/vortex_dir/vortex_objects_dir/semi_infinite_filament.py
@@ -40,9 +40,10 @@ import awebox.tools.print_operations as print_op
 from awebox.logger.logger import Logger as awelogger
 
 import matplotlib
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import awebox.mdl.aero.induction_dir.vortex_dir.tools as vortex_tools
 
-matplotlib.use('TkAgg')
 
 
 class SemiInfiniteFilament(obj_element.Element):

--- a/awebox/mdl/aero/induction_dir/vortex_dir/vortex_objects_dir/semi_infinite_longitudinal_right_cylinder.py
+++ b/awebox/mdl/aero/induction_dir/vortex_dir/vortex_objects_dir/semi_infinite_longitudinal_right_cylinder.py
@@ -43,7 +43,8 @@ import awebox.tools.print_operations as print_op
 from awebox.logger.logger import Logger as awelogger
 
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 
 
 class SemiInfiniteLongitudinalRightCylinder(obj_semi_infinite_right_cylinder.SemiInfiniteRightCylinder):

--- a/awebox/mdl/aero/induction_dir/vortex_dir/vortex_objects_dir/semi_infinite_right_cylinder.py
+++ b/awebox/mdl/aero/induction_dir/vortex_dir/vortex_objects_dir/semi_infinite_right_cylinder.py
@@ -41,7 +41,8 @@ from awebox.logger.logger import Logger as awelogger
 
 import matplotlib
 import awebox.mdl.aero.induction_dir.general_dir.tools as general_tools
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 
 class SemiInfiniteRightCylinder(obj_element.Element):
     def __init__(self, info_dict, approximation_order_for_elliptic_integrals=6):

--- a/awebox/mdl/aero/induction_dir/vortex_dir/vortex_objects_dir/semi_infinite_skewed_cylinder.py
+++ b/awebox/mdl/aero/induction_dir/vortex_dir/vortex_objects_dir/semi_infinite_skewed_cylinder.py
@@ -42,7 +42,8 @@ from awebox.logger.logger import Logger as awelogger
 
 import matplotlib
 import awebox.mdl.aero.induction_dir.general_dir.tools as general_tools
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 
 class SemiInfiniteRightCylinder(obj_element.Element):
     def __init__(self, info_dict, approximation_order_for_elliptic_integrals=6):

--- a/awebox/mdl/aero/induction_dir/vortex_dir/vortex_objects_dir/semi_infinite_tangential_right_cylinder.py
+++ b/awebox/mdl/aero/induction_dir/vortex_dir/vortex_objects_dir/semi_infinite_tangential_right_cylinder.py
@@ -28,7 +28,8 @@ _python-3.5 / casadi-3.4.5
 - authors: rachel leuthold 2021-2022
 '''
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
 
 import casadi.tools as cas
@@ -47,7 +48,7 @@ from awebox.logger.logger import Logger as awelogger
 import matplotlib
 import scipy.special as special
 
-matplotlib.use('TkAgg')
+matplotlib.use(DEFAULT_MPL_BACKEND)
 
 
 class SemiInfiniteTangentialRightCylinder(obj_semi_infinite_right_cylinder.SemiInfiniteRightCylinder):

--- a/awebox/mdl/aero/induction_dir/vortex_dir/vortex_objects_dir/wake.py
+++ b/awebox/mdl/aero/induction_dir/vortex_dir/vortex_objects_dir/wake.py
@@ -38,7 +38,8 @@ import awebox.tools.print_operations as print_op
 from awebox.logger.logger import Logger as awelogger
 
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 
 class Wake():
     def __init__(self):

--- a/awebox/mdl/aero/induction_dir/vortex_dir/vortex_objects_dir/wake_substructure.py
+++ b/awebox/mdl/aero/induction_dir/vortex_dir/vortex_objects_dir/wake_substructure.py
@@ -45,7 +45,8 @@ import awebox.mdl.aero.induction_dir.vortex_dir.vortex_objects_dir.semi_infinite
 from awebox.logger.logger import Logger as awelogger
 
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 
 class WakeSubstructure():
     def __init__(self, substructure_type=None):

--- a/awebox/mdl/aero/tether_dir/coefficients.py
+++ b/awebox/mdl/aero/tether_dir/coefficients.py
@@ -28,7 +28,8 @@ _python-3.5 / casadi-3.4.5
 - author: rachel leuthold, alu-fr 2018
 '''
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
 
 import casadi.tools as cas

--- a/awebox/pmpc.py
+++ b/awebox/pmpc.py
@@ -28,7 +28,8 @@ Periodic MPC routines for awebox models
 :author: Jochem De Schutter (ALU Freiburg 2019)
 """
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
 
 import awebox as awe

--- a/awebox/sweep.py
+++ b/awebox/sweep.py
@@ -31,7 +31,8 @@ edit: rachel leuthold, alu-fr, 2020
 
 
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
 
 

--- a/awebox/tools/debug_operations.py
+++ b/awebox/tools/debug_operations.py
@@ -33,7 +33,8 @@ import datetime
 
 
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
 
 import casadi.tools as cas

--- a/awebox/tools/vector_operations.py
+++ b/awebox/tools/vector_operations.py
@@ -28,7 +28,8 @@ _python-3.5 / casadi-3.4.5
 - author: rachel leuthold, jochem de schutter alu-fr 2017-19
 '''
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
 
 

--- a/awebox/viz/animation.py
+++ b/awebox/viz/animation.py
@@ -28,7 +28,8 @@ python-3.5 / casadi 3.0.0
 - authors: jochem de schutter, rachel leuthold alu-fr 2018-2020
 """
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
 
 

--- a/awebox/viz/comparison.py
+++ b/awebox/viz/comparison.py
@@ -24,7 +24,8 @@
 #
 
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
 
 

--- a/awebox/viz/output.py
+++ b/awebox/viz/output.py
@@ -24,7 +24,8 @@
 #
 
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
 
 

--- a/awebox/viz/plot_configuration.py
+++ b/awebox/viz/plot_configuration.py
@@ -1,0 +1,27 @@
+#
+#    This file is part of awebox.
+#
+#    awebox -- A modeling and optimization framework for multi-kite AWE systems.
+#    Copyright (C) 2017-2020 Jochem De Schutter, Rachel Leuthold, Moritz Diehl,
+#                            ALU Freiburg.
+#    Copyright (C) 2018-2020 Thilo Bronnenmeyer, Kiteswarms Ltd.
+#    Copyright (C) 2016      Elena Malz, Sebastien Gros, Chalmers UT.
+#
+#    awebox is free software; you can redistribute it and/or
+#    modify it under the terms of the GNU Lesser General Public
+#    License as published by the Free Software Foundation; either
+#    version 3 of the License, or (at your option) any later version.
+#
+#    awebox is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with awebox; if not, write to the Free Software Foundation,
+#    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+#
+
+# Set the default matplot backend, for more details see: https://matplotlib.org/stable/users/explain/figure/backends.htm
+DEFAULT_MPL_BACKEND = 'TkAgg'

--- a/awebox/viz/tools.py
+++ b/awebox/viz/tools.py
@@ -24,7 +24,8 @@
 #
 
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
 
 import casadi.tools as cas

--- a/awebox/viz/trajectory.py
+++ b/awebox/viz/trajectory.py
@@ -25,7 +25,8 @@
 
 
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
 
 import awebox.viz.tools as tools

--- a/awebox/viz/variables.py
+++ b/awebox/viz/variables.py
@@ -27,7 +27,8 @@
 import matplotlib
 import awebox.tools.vector_operations as vect_op
 
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
 import awebox.tools.struct_operations as struct_op
 import awebox.tools.print_operations as print_op

--- a/awebox/viz/visualization.py
+++ b/awebox/viz/visualization.py
@@ -38,7 +38,8 @@ import os
 
 
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
 import awebox.tools.print_operations as print_op
 import awebox.tools.vector_operations as vect_op

--- a/awebox/viz/wake.py
+++ b/awebox/viz/wake.py
@@ -25,7 +25,8 @@
 import copy
 
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
 
 

--- a/test/int/test_visualization.py
+++ b/test/int/test_visualization.py
@@ -4,7 +4,8 @@
 @author: Thilo Bronnenmeyer
 """
 import matplotlib
-matplotlib.use('TkAgg')
+from awebox.viz.plot_configuration import DEFAULT_MPL_BACKEND
+matplotlib.use(DEFAULT_MPL_BACKEND)
 import matplotlib.pyplot as plt
 import numpy as np
 


### PR DESCRIPTION
Added a file `viz/plot_configuration` that defines only one variable:
```python
DEFAULT_MPL_BACKEND = 'TkAgg'
```
that is then loaded whenever the backend is changed in the other files (which for some reason is in a lot of places).

Kind of a suboptimal solution. The `tkagg` backend should only be loaded in the file where it is actually used/needed.

[https://matplotlib.org/stable/users/explain/figure/backends.html](https://matplotlib.org/stable/users/explain/figure/backends.html)

For future: let the user set the backend with an environment variable `MPLBACKEND=tkagg` or a `matplotlibrc` file, and remove all the unecessary `matplotlib.use(...)` calls.
